### PR TITLE
🚨 Pylint Fixes: use-dict-literal

### DIFF
--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -28,7 +28,7 @@ class ConditionNodeBuilder:
             self.format_constraints_condition_keys,
         ) = self._seperate_condition_keys_into_each_type()
 
-    def _seperate_condition_keys_into_each_type(self) -> Tuple[List[str]]:
+    def _seperate_condition_keys_into_each_type(self) -> Tuple[List[str], List[str], List[str]]:
         """
         Seperates the list of all condition keys into three lists of their respective types.
         The types are differentiated by their number range.


### PR DESCRIPTION
https://github.com/Hochfrequenz/ahbicht/runs/3401859671
>************* Module ahbicht.condition_node_builder
src/ahbicht/condition_node_builder.py:54:26: R1735: Consider using {} instead of dict() (use-dict-literal)
src/ahbicht/condition_node_builder.py:66:41: R1735: Consider using {} instead of dict() (use-dict-literal)
src/ahbicht/condition_node_builder.py:83:44: R1735: Consider using {} instead of dict() (use-dict-literal)