### PR TITLE
🎨 Add setup.py to avoid error in running tests env more than once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
During the setup and first run of the tests/coverage environment everything was fine.
But if you try to run it again, you got the following error message:
```
ERROR: invocation failed (exit code 2)
____________________________________________________________________ summary ____________________________________________________________________
ERROR:   tests: InvocationError for command 'C:\workspaces_test\ahbicht\.tox\tests\Scripts\python' 'C:\workspaces_test\ahbicht\setup.py' --name (exited with code 2)
```
the setup.py file seems to be needed for some tools.