### PR TITLE
Add py.typed file to indicate the package supports type hints

### DIFF
--- a/src/ahbicht/py.typed
+++ b/src/ahbicht/py.typed
@@ -1,1 +1,2 @@
-
+# Instruct type checkers to look for inline type annotations in this package.
+# See PEP 561.


### PR DESCRIPTION
See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

> If you would like to publish a library package to a package repository yourself (e.g. on PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory.