### PR TITLE
♻ Rename ConditionCheckResult and correct default values

### DIFF
--- a/minimal_working_example.ipynb
+++ b/minimal_working_example.ipynb
@@ -317,7 +317,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ConditionCheckResult(requirement_indicator='Muss', requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None))\n"
+      "AhbExpressionEvaluationResult(requirement_indicator='Muss', requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None))\n"
      ]
     }
    ],

--- a/src/ahbicht/evaluation_results.py
+++ b/src/ahbicht/evaluation_results.py
@@ -83,7 +83,7 @@ class FormatConstraintEvaluationResultSchema(Schema):
 @attr.s(auto_attribs=True, kw_only=True)
 class AhbExpressionEvaluationResult:
     """
-    A class for the result of the overall condition check.
+    A class for the result of an ahb expression evaluation.
     """
 
     requirement_indicator: str  # i.e. "Muss", "M", "Soll", "S", "Kann", "K", "X", "O", "U"

--- a/src/ahbicht/evaluation_results.py
+++ b/src/ahbicht/evaluation_results.py
@@ -20,10 +20,10 @@ class RequirementConstraintEvaluationResult:
     requirement_constraints_fulfilled: bool  # true if condition expression in regard to
     # requirement constraints evaluates to true
     requirement_is_conditional: bool  # true if it is dependent on requirement constraints
-    format_constraints_expression: Optional[str]
-    hints: Optional[
-        str
-    ]  # Hint text that should be displayed in the frontend, e.g. "[501] Hinweis: 'ID der Messlokation'"
+
+    format_constraints_expression: Optional[str] = attr.ib(default=None)
+    hints: Optional[str] = attr.ib(default=None)  # Hint text that should be displayed in the frontend,
+    # e.g. "[501] Hinweis: 'ID der Messlokation'"
 
 
 class RequirementConstraintEvaluationResultSchema(Schema):
@@ -33,8 +33,9 @@ class RequirementConstraintEvaluationResultSchema(Schema):
 
     requirement_constraints_fulfilled = fields.Boolean()
     requirement_is_conditional = fields.Boolean()
-    format_constraints_expression = fields.String()
-    hints = fields.String()
+
+    format_constraints_expression = fields.String(load_default=None)
+    hints = fields.String(load_default=None)
 
     @post_load
     def deserialize(self, data, **kwargs) -> RequirementConstraintEvaluationResult:
@@ -54,7 +55,10 @@ class FormatConstraintEvaluationResult:
     """
 
     format_constraints_fulfilled: bool  # true if data entered obey the format constraint expression
-    error_message: Optional[str]  # All error messages that lead to not fulfilling the format constraint expression
+
+    error_message: Optional[str] = attr.ib(
+        default=None
+    )  # All error messages that lead to not fulfilling the format constraint expression
 
 
 class FormatConstraintEvaluationResultSchema(Schema):
@@ -63,7 +67,7 @@ class FormatConstraintEvaluationResultSchema(Schema):
     """
 
     format_constraints_fulfilled = fields.Boolean()
-    error_message = fields.String(allow_none=True)
+    error_message = fields.String(allow_none=True, missing=None)
 
     @post_load
     def deserialize(self, data, **kwargs) -> FormatConstraintEvaluationResult:

--- a/src/ahbicht/evaluation_results.py
+++ b/src/ahbicht/evaluation_results.py
@@ -77,7 +77,7 @@ class FormatConstraintEvaluationResultSchema(Schema):
 
 
 @attr.s(auto_attribs=True, kw_only=True)
-class ConditionCheckResult:
+class AhbExpressionEvaluationResult:
     """
     A class for the result of the overall condition check.
     """
@@ -87,9 +87,9 @@ class ConditionCheckResult:
     format_constraint_evaluation_result: FormatConstraintEvaluationResult
 
 
-class ConditionCheckResultSchema(Schema):
+class AhbExpressionEvaluationResultSchema(Schema):
     """
-    A schema to (de-)serialize ConditionCheckResults
+    A schema to (de-)serialize AhbExpressionEvaluationResults
     """
 
     requirement_indicator = fields.String(required=True, allow_none=True)
@@ -97,11 +97,11 @@ class ConditionCheckResultSchema(Schema):
     format_constraint_evaluation_result = fields.Nested(FormatConstraintEvaluationResultSchema())
 
     @post_load
-    def deserialize(self, data, **kwargs) -> ConditionCheckResult:
+    def deserialize(self, data, **kwargs) -> AhbExpressionEvaluationResult:
         """
-        Converts the barely typed data dictionary into an actual ConditionCheckResult
+        Converts the barely typed data dictionary into an actual AhbExpressionEvaluationResult
         :param data:
         :param kwargs:
         :return:
         """
-        return ConditionCheckResult(**data)
+        return AhbExpressionEvaluationResult(**data)

--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -10,8 +10,8 @@ from typing import List
 from lark import Token, Transformer, Tree, v_args
 from lark.exceptions import VisitError
 
-from ahbicht.condition_check_results import (
-    ConditionCheckResult,
+from ahbicht.evaluation_results import (
+    AhbExpressionEvaluationResult,
     FormatConstraintEvaluationResult,
     RequirementConstraintEvaluationResult,
 )
@@ -51,7 +51,7 @@ class AhbExpressionTransformer(Transformer):
     @v_args(inline=True)  # Children are provided as *args instead of a list argument
     def single_requirement_indicator_expression(
         self, requirement_indicator, condition_expression
-    ) -> ConditionCheckResult:
+    ) -> AhbExpressionEvaluationResult:
         """
         Evaluates the condition expression of the respective requirement indicator expression
         and returns a list of the seperated requirement indicators with
@@ -64,7 +64,7 @@ class AhbExpressionTransformer(Transformer):
             requirement_constraint_evaluation_result.format_constraints_expression, self.entered_input
         )
 
-        result_of_condition_check: ConditionCheckResult = ConditionCheckResult(
+        result_of_condition_check: AhbExpressionEvaluationResult = AhbExpressionEvaluationResult(
             requirement_indicator=requirement_indicator,
             requirement_constraint_evaluation_result=requirement_constraint_evaluation_result,
             format_constraint_evaluation_result=format_constraint_evaluation_result,
@@ -73,12 +73,12 @@ class AhbExpressionTransformer(Transformer):
         return result_of_condition_check
 
     @v_args(inline=True)  # Children are provided as *args instead of a list argument
-    def requirement_indicator(self, requirement_indicator) -> ConditionCheckResult:
+    def requirement_indicator(self, requirement_indicator) -> AhbExpressionEvaluationResult:
         """
         If there is no condition expression but only a requirement indicator,
         all evaluations are automatically set to True.
         """
-        return ConditionCheckResult(
+        return AhbExpressionEvaluationResult(
             requirement_indicator=requirement_indicator,
             requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(
                 requirement_constraints_fulfilled=True,
@@ -93,8 +93,8 @@ class AhbExpressionTransformer(Transformer):
 
     # pylint: disable=(line-too-long)
     def ahb_expression(
-        self, list_of_single_requirement_indicator_expressions: List[ConditionCheckResult]
-    ) -> ConditionCheckResult:
+        self, list_of_single_requirement_indicator_expressions: List[AhbExpressionEvaluationResult]
+    ) -> AhbExpressionEvaluationResult:
         """
         Returns the requirement indicator with its condition expressions already evaluated to booleans.
         If there are more than one modal mark the first whose conditions are fulfilled is returned or the
@@ -114,7 +114,7 @@ class AhbExpressionTransformer(Transformer):
         return list_of_single_requirement_indicator_expressions[-1]
 
 
-def evaluate_ahb_expression_tree(parsed_tree: Tree, entered_input: str) -> ConditionCheckResult:
+def evaluate_ahb_expression_tree(parsed_tree: Tree, entered_input: str) -> AhbExpressionEvaluationResult:
     """
     Evaluates the tree built from the ahb expressions with the help of the AhbExpressionTransformer.
 

--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -64,13 +64,13 @@ class AhbExpressionTransformer(Transformer):
             requirement_constraint_evaluation_result.format_constraints_expression, self.entered_input
         )
 
-        result_of_condition_check: AhbExpressionEvaluationResult = AhbExpressionEvaluationResult(
+        result_of_ahb_expression_evaluation: AhbExpressionEvaluationResult = AhbExpressionEvaluationResult(
             requirement_indicator=requirement_indicator,
             requirement_constraint_evaluation_result=requirement_constraint_evaluation_result,
             format_constraint_evaluation_result=format_constraint_evaluation_result,
         )
 
-        return result_of_condition_check
+        return result_of_ahb_expression_evaluation
 
     @v_args(inline=True)  # Children are provided as *args instead of a list argument
     def requirement_indicator(self, requirement_indicator) -> AhbExpressionEvaluationResult:

--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -13,7 +13,7 @@ import inject
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
 
-from ahbicht.condition_check_results import FormatConstraintEvaluationResult
+from ahbicht.evaluation_results import FormatConstraintEvaluationResult
 from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
 from ahbicht.expressions.base_transformer import BaseTransformer
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -11,7 +11,7 @@ from typing import List, Literal, Mapping, Type
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
 
-from ahbicht.condition_check_results import RequirementConstraintEvaluationResult
+from ahbicht.evaluation_results import RequirementConstraintEvaluationResult
 from ahbicht.condition_node_builder import ConditionNodeBuilder, TRCTransformerArgument
 from ahbicht.expressions.base_transformer import BaseTransformer
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import inject
 import pytest
 
-from ahbicht.condition_check_results import FormatConstraintEvaluationResult, RequirementConstraintEvaluationResult
+from ahbicht.evaluation_results import FormatConstraintEvaluationResult, RequirementConstraintEvaluationResult
 from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
 from ahbicht.expressions.ahb_expression_evaluation import evaluate_ahb_expression_tree
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -3,7 +3,7 @@
 import inject
 import pytest
 
-from ahbicht.condition_check_results import FormatConstraintEvaluationResult
+from ahbicht.evaluation_results import FormatConstraintEvaluationResult
 from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
 from ahbicht.edifact import EdifactFormat, EdifactFormatVersion
 from ahbicht.expressions.condition_nodes import EvaluatedFormatConstraint

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -9,9 +9,9 @@ import pytest
 from lark import Token, Tree
 from marshmallow import Schema, ValidationError
 
-from ahbicht.condition_check_results import (
-    ConditionCheckResult,
-    ConditionCheckResultSchema,
+from ahbicht.evaluation_results import (
+    AhbExpressionEvaluationResult,
+    AhbExpressionEvaluationResultSchema,
     FormatConstraintEvaluationResult,
     RequirementConstraintEvaluationResult,
 )
@@ -215,10 +215,10 @@ class TestJsonSerialization:
             assert isinstance(rc_evaluation_result, ConditionFulfilledValue)
 
     @pytest.mark.parametrize(
-        "condition_check_result, expected_json_dict",
+        "ahb_expression_evaluation_result, expected_json_dict",
         [
             pytest.param(
-                ConditionCheckResult(
+                AhbExpressionEvaluationResult(
                     requirement_indicator="Muss",
                     format_constraint_evaluation_result=FormatConstraintEvaluationResult(
                         error_message="hello", format_constraints_fulfilled=False
@@ -246,7 +246,10 @@ class TestJsonSerialization:
             ),
         ],
     )
-    def test_condition_check_result_serialization(
-        self, condition_check_result: ConditionCheckResult, expected_json_dict: dict
+    def test_ahb_expression_evaluation_result_serialization(
+        self, ahb_expression_evaluation_result: AhbExpressionEvaluationResult, expected_json_dict: dict
     ):
-        _test_serialization_roundtrip(condition_check_result, ConditionCheckResultSchema(), expected_json_dict)
+        _test_serialization_roundtrip(
+            ahb_expression_evaluation_result, AhbExpressionEvaluationResultSchema(), expected_json_dict
+        )
+

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -253,3 +253,67 @@ class TestJsonSerialization:
             ahb_expression_evaluation_result, AhbExpressionEvaluationResultSchema(), expected_json_dict
         )
 
+    @pytest.mark.parametrize(
+        "ahb_expression_evaluation_result, expected_json_dict",
+        [
+            pytest.param(
+                AhbExpressionEvaluationResult(
+                    requirement_indicator="Muss",
+                    format_constraint_evaluation_result=FormatConstraintEvaluationResult(
+                        error_message="hello", format_constraints_fulfilled=False
+                    ),
+                    requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(
+                        hints="foo bar",
+                        requirement_constraints_fulfilled=True,
+                        requirement_is_conditional=True,
+                        format_constraints_expression="[asd]",
+                    ),
+                ),
+                {
+                    "format_constraint_evaluation_result": {
+                        "error_message": "hello",
+                        "format_constraints_fulfilled": False,
+                    },
+                    "requirement_constraint_evaluation_result": {
+                        "format_constraints_expression": "[asd]",
+                        "hints": "foo bar",
+                        "requirement_constraints_fulfilled": True,
+                        "requirement_is_conditional": True,
+                    },
+                    "requirement_indicator": "Muss",
+                },
+            ),
+            pytest.param(
+                AhbExpressionEvaluationResult(
+                    requirement_indicator="Muss",
+                    format_constraint_evaluation_result=FormatConstraintEvaluationResult(
+                        format_constraints_fulfilled=False
+                    ),
+                    requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(
+                        requirement_constraints_fulfilled=True,
+                        requirement_is_conditional=True,
+                    ),
+                ),
+                {
+                    "format_constraint_evaluation_result": {
+                        "error_message": None,
+                        "format_constraints_fulfilled": False,
+                    },
+                    "requirement_constraint_evaluation_result": {
+                        "format_constraints_expression": None,
+                        "hints": None,
+                        "requirement_constraints_fulfilled": True,
+                        "requirement_is_conditional": True,
+                    },
+                    "requirement_indicator": "Muss",
+                },
+                id="Minimal example",
+            ),
+        ],
+    )
+    def test_ahb_expression_evaluation_result_serialization(
+        self, ahb_expression_evaluation_result: AhbExpressionEvaluationResult, expected_json_dict: dict
+    ):
+        _test_serialization_roundtrip(
+            ahb_expression_evaluation_result, AhbExpressionEvaluationResultSchema(), expected_json_dict
+        )

--- a/unittests/test_requirement_constraint_evaluation.py
+++ b/unittests/test_requirement_constraint_evaluation.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import inject
 import pytest
 
-from ahbicht.condition_check_results import RequirementConstraintEvaluationResult
+from ahbicht.evaluation_results import RequirementConstraintEvaluationResult
 from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
 from ahbicht.expressions.condition_nodes import (
     ConditionFulfilledValue,


### PR DESCRIPTION
Kleiner Renaming and Refactoring PR um es vom inhaltlichen PR zu trennen.

* Renaming ConditionCheckResult to AhbExpressionEvaluationResult to make it more clear
*  Rename file condition_check_results to evaluation_results
* Make default values of evaluation results really default