### PR TITLE
🎨 Type check the Unittests, too

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
     mypy
 commands =
     mypy --show-error-codes src/ahbicht
+    mypy --show-error-codes unittests
 # add single files (ending with .py) or packages here
 
 [testenv:coverage]

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -161,6 +161,8 @@ class TestAHBExpressionEvaluation:
         parsed_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(expression)
 
         with pytest.raises(expected_error) as excinfo:
-            evaluate_ahb_expression_tree(parsed_tree, entered_input=None)
+            evaluate_ahb_expression_tree(
+                parsed_tree, entered_input=None  # type:ignore[arg-type] # ok because error test
+            )
 
         assert expected_error_message in str(excinfo.value)

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock
 
 import inject
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
 from ahbicht.evaluation_results import FormatConstraintEvaluationResult, RequirementConstraintEvaluationResult

--- a/unittests/test_ahb_expression_parser.py
+++ b/unittests/test_ahb_expression_parser.py
@@ -1,6 +1,6 @@
 """ Tests for the parsing of the ahb_expressions as they appear in the AHBs. """
 
-import pytest
+import pytest  # type:ignore[import]
 from lark import Token, Tree
 
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions

--- a/unittests/test_condition_node_builder.py
+++ b/unittests/test_condition_node_builder.py
@@ -23,7 +23,7 @@ class DummyRcEvaluator(RcEvaluator):
     """
 
     def _get_default_context(self) -> EvaluationContext:
-        return None
+        return None  # type:ignore[return-value]
 
     edifact_format = EdifactFormat.UTILMD
     edifact_format_version = EdifactFormatVersion.FV2104

--- a/unittests/test_condition_node_builder.py
+++ b/unittests/test_condition_node_builder.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import inject
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.condition_node_builder import ConditionNodeBuilder
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluationContext

--- a/unittests/test_condition_nodes.py
+++ b/unittests/test_condition_nodes.py
@@ -1,6 +1,6 @@
 """ Tests for creating different condition nodes that are used in the parsed tree. """
 
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.expressions.condition_nodes import (
     ConditionFulfilledValue,

--- a/unittests/test_condition_parser.py
+++ b/unittests/test_condition_parser.py
@@ -1,6 +1,6 @@
 """ Tests for the parsing of the conditions tests (Mussfeldprüfung) """
 
-import pytest
+import pytest  # type:ignore[import]
 from lark import Token, Tree
 
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree

--- a/unittests/test_dict_based_fc_evaluator.py
+++ b/unittests/test_dict_based_fc_evaluator.py
@@ -1,7 +1,7 @@
 """ Tests the dictionary based FC evaluator"""
 from unittest import mock
 
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.fc_evaluators import DictBasedFcEvaluator
 from ahbicht.expressions.condition_nodes import EvaluatedFormatConstraint

--- a/unittests/test_dict_based_rc_evaluator.py
+++ b/unittests/test_dict_based_rc_evaluator.py
@@ -1,7 +1,7 @@
 """ Tests the dictionary based RC evaluator"""
 from unittest import mock
 
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue

--- a/unittests/test_edifact.py
+++ b/unittests/test_edifact.py
@@ -35,4 +35,4 @@ class TestEdifact:
         :return:
         """
         with pytest.raises(ValueError):
-            pruefidentifikator_to_format(illegal_pruefi)
+            pruefidentifikator_to_format(illegal_pruefi)  # type:ignore[arg-type] # ok, because this raises an error

--- a/unittests/test_edifact.py
+++ b/unittests/test_edifact.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple
 
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.edifact import EdifactFormat, pruefidentifikator_to_format
 

--- a/unittests/test_evaluator_factory.py
+++ b/unittests/test_evaluator_factory.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Optional
 
 import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest
+from _pytest.fixtures import SubRequest  # type:ignore[import]
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.evaluator_factory import create_and_inject_hardcoded_evaluators
@@ -67,7 +67,10 @@ class TestEvaluatorFactory:
             expression_evaluation_result.format_constraint_evaluation_result.format_constraints_fulfilled
             is expected_format_constraint_result
         )
-        if expected_in_hints:
-            assert expected_in_hints in expression_evaluation_result.requirement_constraint_evaluation_result.hints
+        if expected_in_hints is not None:
+            assert (
+                expected_in_hints
+                in expression_evaluation_result.requirement_constraint_evaluation_result.hints  # type:ignore[operator]
+            )
         else:
             assert expression_evaluation_result.requirement_constraint_evaluation_result.hints is None

--- a/unittests/test_evaluator_factory.py
+++ b/unittests/test_evaluator_factory.py
@@ -2,7 +2,7 @@
 import uuid
 from typing import Optional
 
-import pytest
+import pytest  # type:ignore[import]
 from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult

--- a/unittests/test_expression_builder.py
+++ b/unittests/test_expression_builder.py
@@ -1,7 +1,7 @@
 """
 Tests the expression builder module.
 """
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.expressions.condition_nodes import Hint, UnevaluatedFormatConstraint
 from ahbicht.expressions.expression_builder import FormatConstraintExpressionBuilder, HintExpressionBuilder

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -26,7 +26,7 @@ class DummyFcEvaluator(FcEvaluator):
         [950] Format: Marktlokations-ID
         """
         # this is just a minimal working example; we skip all the stuff like check digits and so on for simplicity
-        is_malo = entered_input and len(entered_input) == 11
+        is_malo: bool = entered_input and len(entered_input) == 11  # type:ignore[assignment]
         if is_malo:
             error_message = None
         else:
@@ -38,7 +38,7 @@ class DummyFcEvaluator(FcEvaluator):
         [951] Format: Zählpunktbezeichnung
         """
         # this is just a minimal working example; we skip regex matching and integrity checks for simplicity
-        is_zaehlpunkt = entered_input and len(entered_input) == 33
+        is_zaehlpunkt: bool = entered_input and len(entered_input) == 33  # type:ignore[assignment]
         if is_zaehlpunkt:
             error_message = None
         else:
@@ -143,7 +143,7 @@ class TestFormatConstraintExpressionEvaluation:
         )
 
         with pytest.raises(ValueError) as excinfo:
-            format_constraint_evaluation(format_constraints_expression, entered_input=None)
+            format_constraint_evaluation(format_constraints_expression, entered_input=None)  # type:ignore[arg-type]
 
         assert expected_error_message in str(excinfo.value)
 

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -1,7 +1,7 @@
 """ Test for the evaluation of the format constraint expression. """
 
 import inject
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
 from ahbicht.edifact import EdifactFormat, EdifactFormatVersion

--- a/unittests/test_hints_provider.py
+++ b/unittests/test_hints_provider.py
@@ -1,7 +1,7 @@
 """
 Tests the hints provider module.
 """
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.edifact import EdifactFormat, EdifactFormatVersion
 from ahbicht.expressions.hints_provider import JsonFileHintsProvider

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -251,18 +251,6 @@ class TestJsonSerialization:
                     "requirement_indicator": "Muss",
                 },
             ),
-        ],
-    )
-    def test_ahb_expression_evaluation_result_serialization(
-        self, ahb_expression_evaluation_result: AhbExpressionEvaluationResult, expected_json_dict: dict
-    ):
-        _test_serialization_roundtrip(
-            ahb_expression_evaluation_result, AhbExpressionEvaluationResultSchema(), expected_json_dict
-        )
-
-    @pytest.mark.parametrize(
-        "ahb_expression_evaluation_result, expected_json_dict",
-        [
             pytest.param(
                 AhbExpressionEvaluationResult(
                     requirement_indicator="Muss",

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from typing import TypeVar
 
-import pytest
+import pytest  # type:ignore[import]
 from lark import Token, Tree
 from marshmallow import Schema, ValidationError
 

--- a/unittests/test_requirement_constraint_evaluation.py
+++ b/unittests/test_requirement_constraint_evaluation.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock
 
 import inject
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
 from ahbicht.evaluation_results import RequirementConstraintEvaluationResult

--- a/unittests/test_requirement_constraint_expression_evaluation.py
+++ b/unittests/test_requirement_constraint_expression_evaluation.py
@@ -1,7 +1,7 @@
 """ Test for the evaluation of the conditions tests (Mussfeldprüfung) """
 from typing import Dict, Optional
 
-import pytest
+import pytest  # type:ignore[import]
 
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue as cfv

--- a/unittests/test_requirement_constraint_expression_evaluation.py
+++ b/unittests/test_requirement_constraint_expression_evaluation.py
@@ -162,7 +162,7 @@ class TestRequirementConstraintEvaluation:
         }
 
         parsed_tree = parse_condition_expression_to_tree(expression)
-        result: ConditionNode = evaluate_requirement_constraint_tree(parsed_tree, input_values)
+        result: ConditionNode = evaluate_requirement_constraint_tree(parsed_tree, input_values)  # type:ignore[arg-type]
 
         assert result.conditions_fulfilled == expected_resulting_conditions_fulfilled
         assert getattr(result, "hint", None) == expected_resulting_hint
@@ -204,7 +204,9 @@ class TestRequirementConstraintEvaluation:
             "988": self._fc_988,
         }
         parsed_tree = parse_condition_expression_to_tree(expression)
-        result: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree, input_values)
+        result: EvaluatedComposition = evaluate_requirement_constraint_tree(
+            parsed_tree, input_values  # type:ignore[arg-type]
+        )
         assert isinstance(result, EvaluatedComposition)
         assert result.conditions_fulfilled == expected_resulting_conditions_fulfilled
         assert result.hint == expected_hint_text
@@ -248,7 +250,9 @@ class TestRequirementConstraintEvaluation:
             "987": self._fc_987,
         }
         parsed_tree = parse_condition_expression_to_tree(expression)
-        result: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree, input_values)
+        result: EvaluatedComposition = evaluate_requirement_constraint_tree(
+            parsed_tree, input_values  # type:ignore[arg-type]
+        )
         assert isinstance(result, ConditionNode)
         assert result.conditions_fulfilled == expected_resulting_conditions_fulfilled
 
@@ -311,7 +315,7 @@ class TestRequirementConstraintEvaluation:
         parsed_tree = parse_condition_expression_to_tree(expression)
 
         with pytest.raises(NotImplementedError) as excinfo:
-            evaluate_requirement_constraint_tree(parsed_tree, input_values)
+            evaluate_requirement_constraint_tree(parsed_tree, input_values)  # type:ignore[arg-type]
 
         assert """is not implemented as it has no useful result.""" in str(excinfo.value)
 
@@ -368,6 +372,8 @@ class TestRequirementConstraintEvaluation:
         input_values["950"] = self._fc_950
         input_values["951"] = self._fc_951
         parsed_tree = parse_condition_expression_to_tree("([950] ([2] U [4])) O ([951] ([1] U [3]))")
-        actual: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree, input_values)
+        actual: EvaluatedComposition = evaluate_requirement_constraint_tree(
+            parsed_tree, input_values  # type:ignore[arg-type]
+        )
         assert isinstance(actual, EvaluatedComposition)
         assert actual == expected_evaluated_result


### PR DESCRIPTION
See also https://github.com/Hochfrequenz/BO4E-python/pull/69

Actually this PR shows:
- that there is still some typing pain with the distinction between Condition Nodes in general and more restrictive ones
> error: Argument 2 to "evaluate_requirement_constraint_tree" has incompatible type "Dict[str, ConditionNode]"; expected "Mapping[str, Union[RequirementConstraint, UnevaluatedFormatConstraint, Hint]]"  [arg-type]

- that one test method was duplicated accidentially