### PR TITLE
🎨 Improve Async Evaluators

### DIFF
--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -2,7 +2,6 @@
 Module for taking all the condition keys of a condition expression and building their respective ConditionNodes.
 If necessary it evaluates the needed attributes.
 """
-import asyncio
 from typing import Dict, List, Tuple, Union
 
 import inject
@@ -50,11 +49,9 @@ class ConditionNodeBuilder:
             categorized_keys.format_constraint_keys,
         )
 
-    def _build_hint_nodes(self) -> Dict[str, Hint]:
+    async def _build_hint_nodes(self) -> Dict[str, Hint]:
         """Builds Hint nodes from their condition keys by getting all hint texts from the HintsProvider."""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        return loop.run_until_complete(self.hints_provider.get_hints(self.hints_condition_keys))
+        return await self.hints_provider.get_hints(self.hints_condition_keys)
 
     def _build_unevaluated_format_constraint_nodes(self) -> Dict[str, UnevaluatedFormatConstraint]:
         """Build unevaluated format constraint nodes."""
@@ -63,18 +60,15 @@ class ConditionNodeBuilder:
             unevaluated_format_constraints[condition_key] = UnevaluatedFormatConstraint(condition_key=condition_key)
         return unevaluated_format_constraints
 
-    def _build_requirement_constraint_nodes(self) -> Dict[str, RequirementConstraint]:
+    async def _build_requirement_constraint_nodes(self) -> Dict[str, RequirementConstraint]:
         """
         Build requirement constraint nodes by evaluating the constraints
         with the help of the respective Evaluator.
         """
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        evaluated_conditions_fulfilled_attribute: dict = loop.run_until_complete(
-            self.rc_evaluator.evaluate_conditions(self.requirement_constraints_condition_keys)
+        evaluated_conditions_fulfilled_attribute = await self.rc_evaluator.evaluate_conditions(
+            self.requirement_constraints_condition_keys
         )
-
         evaluated_requirement_constraints: Dict[str, RequirementConstraint] = {}
         for condition_key in self.requirement_constraints_condition_keys:
             evaluated_requirement_constraints[condition_key] = RequirementConstraint(
@@ -83,12 +77,12 @@ class ConditionNodeBuilder:
             )
         return evaluated_requirement_constraints
 
-    def requirement_content_evaluation_for_all_condition_keys(
+    async def requirement_content_evaluation_for_all_condition_keys(
         self,
     ) -> Dict[str, TRCTransformerArgument]:
         """Gets input nodes for all condition keys."""
-        requirement_constraint_nodes = self._build_requirement_constraint_nodes()
-        hint_nodes = self._build_hint_nodes()
+        requirement_constraint_nodes = await self._build_requirement_constraint_nodes()
+        hint_nodes = await self._build_hint_nodes()
         unevaluated_format_constraint_nodes = self._build_unevaluated_format_constraint_nodes()
         input_nodes: Dict[str, TRCTransformerArgument] = {
             **requirement_constraint_nodes,

--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -67,7 +67,7 @@ class ConditionNodeBuilder:
         """
 
         evaluated_conditions_fulfilled_attribute = await self.rc_evaluator.evaluate_conditions(
-            self.requirement_constraints_condition_keys
+            condition_keys=self.requirement_constraints_condition_keys
         )
         evaluated_requirement_constraints: Dict[str, RequirementConstraint] = {}
         for condition_key in self.requirement_constraints_condition_keys:

--- a/src/ahbicht/content_evaluation/fc_evaluators.py
+++ b/src/ahbicht/content_evaluation/fc_evaluators.py
@@ -8,6 +8,7 @@ Other than requirement constraints format constraints do not affect if data are 
 validate already required data.
 """
 import asyncio
+import inspect
 from abc import ABC
 from typing import Coroutine, Dict, List
 
@@ -36,8 +37,11 @@ class FcEvaluator(Evaluator, ABC):
         evaluation_method = self.get_evaluation_method(condition_key)
         if evaluation_method is None:
             raise NotImplementedError(f"There is no content_evaluation method for format constraint '{condition_key}'")
-        result: EvaluatedFormatConstraint = await evaluation_method(entered_input)
-
+        result: EvaluatedFormatConstraint
+        if inspect.iscoroutinefunction(evaluation_method):
+            result = await evaluation_method(entered_input)
+        else:
+            result = evaluation_method(entered_input)
         # Fallback error message if there is no error message even though format constraint isn't fulfilled
         if result.format_constraint_fulfilled is False and result.error_message is None:
             result.error_message = f"Condition [{condition_key}] has to be fulfilled."

--- a/src/ahbicht/content_evaluation/rc_evaluators.py
+++ b/src/ahbicht/content_evaluation/rc_evaluators.py
@@ -5,6 +5,7 @@ Typical usecases are for example
 * you must only provide an Ausbaudatum if the meter is being removed f.e. 'Z02'
 """
 import asyncio
+import inspect
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
@@ -12,8 +13,9 @@ from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, Eval
 from ahbicht.content_evaluation.evaluators import Evaluator
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue
 
-
 # pylint: disable=no-self-use
+
+
 class RcEvaluator(Evaluator, ABC):
     """
     Base class of all Requirement Constraint (RC) evaluators.
@@ -49,8 +51,9 @@ class RcEvaluator(Evaluator, ABC):
             raise NotImplementedError(f"There is no content_evaluation method for condition '{condition_key}'")
         if context is None:
             context = self._get_default_context()
-        result = await evaluation_method(context)
-        return result
+        if inspect.iscoroutinefunction(evaluation_method):
+            return await evaluation_method(context)
+        return evaluation_method(context)
 
     async def evaluate_conditions(
         self, condition_keys: List[str], condition_keys_with_context: Optional[Dict[str, EvaluationContext]] = None

--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -6,7 +6,6 @@ of the format constraint expression tree are handled.
 The used terms are defined in the README_conditions.md.
 """
 
-import asyncio
 from typing import Dict, List, Mapping, Optional
 
 import inject
@@ -89,7 +88,7 @@ def evaluate_format_constraint_tree(
     return result
 
 
-def format_constraint_evaluation(
+async def format_constraint_evaluation(
     format_constraints_expression: Optional[str], entered_input: str
 ) -> FormatConstraintEvaluationResult:
     """
@@ -104,7 +103,7 @@ def format_constraint_evaluation(
         all_evaluatable_format_constraint_keys: List[str] = [
             t.value for t in parsed_tree_fc.scan_values(lambda v: isinstance(v, Token))  # type:ignore[attr-defined]
         ]
-        input_values: Dict[str, EvaluatedFormatConstraint] = _build_evaluated_format_constraint_nodes(
+        input_values: Dict[str, EvaluatedFormatConstraint] = await _build_evaluated_format_constraint_nodes(
             all_evaluatable_format_constraint_keys, entered_input
         )
         resulting_evaluated_format_constraint_node: EvaluatedFormatConstraint = evaluate_format_constraint_tree(
@@ -118,16 +117,13 @@ def format_constraint_evaluation(
     )
 
 
-def _build_evaluated_format_constraint_nodes(
+async def _build_evaluated_format_constraint_nodes(
     evaluatable_format_constraint_keys: List[str], entered_input: str
 ) -> Dict[str, EvaluatedFormatConstraint]:
     """Build evaluated format constraint nodes."""
 
     evaluator: FcEvaluator = inject.instance(FcEvaluator)
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    evaluated_format_constraints: dict = loop.run_until_complete(
-        evaluator.evaluate_format_constraints(evaluatable_format_constraint_keys, entered_input)
+    evaluated_format_constraints = await evaluator.evaluate_format_constraints(
+        evaluatable_format_constraint_keys, entered_input
     )
-
     return evaluated_format_constraints

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -143,7 +143,7 @@ class RequirementConstraintTransformer(BaseTransformer[TRCTransformerArgument, E
         a strict separation of the Mussfeldprüfung itself and evaluation of format constraints on fields
         that have been marked obligatory by the (previously run) Mussfeldprüfung but do not affect
         the result of the Mussfeldprüfung.
-        (Things that are obligatory are obligatory regardless of the format constraints.)
+        (Things that are obligatory, are obligatory regardless of the format constraints.)
 
         :param format_constraint: a format constraint
         :param other_condition: a requirement constraint or hint

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -214,7 +214,9 @@ of the type RequirementConstraint, Hint or FormatConstraint."""
     return result
 
 
-def requirement_constraint_evaluation(condition_expression: Union[str, Tree]) -> RequirementConstraintEvaluationResult:
+async def requirement_constraint_evaluation(
+    condition_expression: Union[str, Tree]
+) -> RequirementConstraintEvaluationResult:
     """
     Evaluation of the condition expression in regard to the requirement conditions (rc).
     The condition expression can either be a string that still needs to be parsed as condition expression or a tree
@@ -230,7 +232,7 @@ def requirement_constraint_evaluation(condition_expression: Union[str, Tree]) ->
         t.value for t in parsed_tree_rc.scan_values(lambda v: isinstance(v, Token))  # type: ignore[attr-defined]
     ]
     condition_node_builder = ConditionNodeBuilder(all_condition_keys)
-    input_nodes = condition_node_builder.requirement_content_evaluation_for_all_condition_keys()
+    input_nodes = await condition_node_builder.requirement_content_evaluation_for_all_condition_keys()
 
     resulting_condition_node: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree_rc, input_nodes)
 

--- a/src/ahbicht/utility_functions.py
+++ b/src/ahbicht/utility_functions.py
@@ -1,0 +1,28 @@
+"""
+Functions that are not clearly related to another module
+"""
+import asyncio
+import inspect
+from typing import Awaitable, List, TypeVar, Union
+
+TResult = TypeVar("TResult")
+
+
+async def gather_if_necessary(results_and_awaitable_results: List[Union[TResult, Awaitable[TResult]]]) -> List[TResult]:
+    """
+    Await the awaitables, pass the un-awaitable results
+    :param results_and_awaitable_results: heterogenous list of both Ts and Awaitable[T]s.
+    :return: list of T in the same order as in the input param.
+    """
+    awaitable_indexes = [n for n, x in enumerate(results_and_awaitable_results) if inspect.isawaitable(x)]
+    awaited_results = await asyncio.gather(*[x for x in results_and_awaitable_results if inspect.isawaitable(x)])
+    result: List[TResult] = []
+    awaited_results_index = 0
+    for index, obj in enumerate(results_and_awaitable_results):
+        if index in awaitable_indexes:
+            result.append(awaited_results[awaited_results_index])
+            awaited_results_index += 1
+        else:
+            # we are sure obj is of type T
+            result.append(obj)  # type:ignore[arg-type]
+    return result

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -114,11 +114,13 @@ class TestAHBExpressionEvaluation:
 
         mocker.patch(
             "ahbicht.expressions.ahb_expression_evaluation.requirement_constraint_evaluation",
-            side_effect=side_effect_rc_evaluation,
+            side_effect=AsyncMock(side_effect=side_effect_rc_evaluation),
         )
         mocker.patch(
             "ahbicht.expressions.ahb_expression_evaluation.format_constraint_evaluation",
-            return_value=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None),
+            return_value=AsyncMock(
+                side_effect=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None)
+            ),
         )
 
         parsed_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -15,6 +15,8 @@ from ahbicht.expressions.condition_nodes import ConditionFulfilledValue, Evaluat
 from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
 from ahbicht.expressions.hints_provider import HintsProvider
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestAHBExpressionEvaluation:
     """Test for the evaluation of the ahb expression conditions tests (Mussfeldprüfung)"""
@@ -57,7 +59,7 @@ class TestAHBExpressionEvaluation:
             pytest.param("Muss[2]Kann", "Kann", True, True, None, None),
         ],
     )
-    def test_evaluate_valid_ahb_expression(
+    async def test_evaluate_valid_ahb_expression(
         self,
         mocker,
         ahb_expression,
@@ -120,7 +122,7 @@ class TestAHBExpressionEvaluation:
         )
 
         parsed_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
-        result = evaluate_ahb_expression_tree(parsed_tree, entered_input=None)
+        result = await evaluate_ahb_expression_tree(parsed_tree, entered_input=None)
 
         assert result.requirement_indicator == expected_requirement_indicator
         assert (
@@ -157,7 +159,7 @@ class TestAHBExpressionEvaluation:
             ),
         ],
     )
-    def test_invalid_ahb_expressions(
+    async def test_invalid_ahb_expressions(
         self, expression: str, expected_error: type, expected_error_message: str, setup_and_teardown_injector
     ):
         """Tests that an error is raised when trying to pass invalid values."""
@@ -165,7 +167,7 @@ class TestAHBExpressionEvaluation:
         parsed_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(expression)
 
         with pytest.raises(expected_error) as excinfo:
-            evaluate_ahb_expression_tree(
+            await evaluate_ahb_expression_tree(
                 parsed_tree, entered_input=None  # type:ignore[arg-type] # ok because error test
             )
 
@@ -190,7 +192,7 @@ class TestAHBExpressionEvaluation:
             )
         ],
     )
-    def test_all_serializations_work_similar(
+    async def test_all_serializations_work_similar(
         self, ahb_expression: str, content_evaluation_result: ContentEvaluationResult
     ):
         tree_a = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
@@ -199,6 +201,6 @@ class TestAHBExpressionEvaluation:
         # but in any case the evaluation result should look the same
         create_and_inject_hardcoded_evaluators(content_evaluation_result)
         evaluation_input = "something has to be here but it's not important what"
-        evaluation_result_a = evaluate_ahb_expression_tree(tree_a, entered_input=evaluation_input)
-        evaluation_result_b = evaluate_ahb_expression_tree(tree_b, entered_input=evaluation_input)
+        evaluation_result_a = await evaluate_ahb_expression_tree(tree_a, entered_input=evaluation_input)
+        evaluation_result_b = await evaluate_ahb_expression_tree(tree_b, entered_input=evaluation_input)
         assert evaluation_result_a == evaluation_result_b

--- a/unittests/test_evaluator_factory.py
+++ b/unittests/test_evaluator_factory.py
@@ -47,7 +47,7 @@ class TestEvaluatorFactory:
             pytest.param("Muss [2] O [3][902]U[501]", "Muss", True, None),
         ],
     )
-    def test_correct_injection(
+    async def test_correct_injection(
         self,
         inject_content_evaluation_result,
         expression: str,
@@ -57,7 +57,7 @@ class TestEvaluatorFactory:
     ):
         tree = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression=expression)
         assert tree is not None
-        expression_evaluation_result = evaluate_ahb_expression_tree(tree, entered_input="hello")
+        expression_evaluation_result = await evaluate_ahb_expression_tree(tree, entered_input="hello")
         assert (
             expression_evaluation_result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled
             is True

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -12,6 +12,8 @@ from ahbicht.expressions.format_constraint_expression_evaluation import (
     format_constraint_evaluation,
 )
 
+pytestmark = pytest.mark.asyncio
+
 
 class DummyFcEvaluator(FcEvaluator):
     """
@@ -96,7 +98,7 @@ class TestFormatConstraintExpressionEvaluation:
             pytest.param("[902]U([904]O[901])", False, "902 muss erfüllt sein"),
         ],
     )
-    def test_evaluate_valid_format_constraint_expression(
+    async def test_evaluate_valid_format_constraint_expression(
         self, mocker, format_constraint_expression, expected_format_constraints_fulfilled, expected_error_message
     ):
         """
@@ -108,7 +110,7 @@ class TestFormatConstraintExpressionEvaluation:
             return_value=self._input_values,
         )
 
-        result = format_constraint_evaluation(format_constraint_expression, entered_input=None)
+        result = await format_constraint_evaluation(format_constraint_expression, entered_input=None)
 
         assert isinstance(result, FormatConstraintEvaluationResult)
         assert result.format_constraints_fulfilled == expected_format_constraints_fulfilled
@@ -129,7 +131,7 @@ class TestFormatConstraintExpressionEvaluation:
             ),
         ],
     )
-    def test_evaluate_format_constraint_expressions_with_invalid_values(
+    async def test_evaluate_format_constraint_expressions_with_invalid_values(
         self,
         mocker,
         format_constraints_expression: str,
@@ -143,7 +145,9 @@ class TestFormatConstraintExpressionEvaluation:
         )
 
         with pytest.raises(ValueError) as excinfo:
-            format_constraint_evaluation(format_constraints_expression, entered_input=None)  # type:ignore[arg-type]
+            await format_constraint_evaluation(
+                format_constraints_expression, entered_input=None  # type:ignore[arg-type]
+            )
 
         assert expected_error_message in str(excinfo.value)
 
@@ -174,9 +178,9 @@ class TestFormatConstraintExpressionEvaluation:
             ),
         ],
     )
-    def test_build_evaluated_format_constraint_nodes(
+    async def test_build_evaluated_format_constraint_nodes(
         self, condition_keys, entered_input, expected_evaluated_fc_nodes, setup_and_teardown_injector
     ):
         """Tests that evaluated format constraints nodes are build correctly."""
-        evaluated_fc_nodes = _build_evaluated_format_constraint_nodes(condition_keys, entered_input)
+        evaluated_fc_nodes = await _build_evaluated_format_constraint_nodes(condition_keys, entered_input)
         assert evaluated_fc_nodes == expected_evaluated_fc_nodes

--- a/unittests/test_hints_provider.py
+++ b/unittests/test_hints_provider.py
@@ -1,12 +1,37 @@
 """
 Tests the hints provider module.
 """
+import asyncio
+import datetime
+
 import pytest  # type:ignore[import]
 
 from ahbicht.edifact import EdifactFormat, EdifactFormatVersion
-from ahbicht.expressions.hints_provider import JsonFileHintsProvider
+from ahbicht.expressions.hints_provider import HintsProvider, JsonFileHintsProvider
 
 pytestmark = pytest.mark.asyncio
+
+
+class Dummy1sHintsProvider(HintsProvider):
+    """a hints provider that takes 1s for each (dummy) hint text"""
+
+    async def get_hint_text(self, _: str):
+        await asyncio.sleep(1)
+        return "foo"
+
+
+class DummyAsyncHintsProvider(HintsProvider):
+    """a hints provider that has an async get_hint_text_method"""
+
+    async def get_hint_text(self, _: str):
+        return "foo"
+
+
+class DummySyncHintsProvider(HintsProvider):
+    """a hints provider that has a sync get_hint_text_method"""
+
+    def get_hint_text(self, _: str):
+        return "foo"
 
 
 class TestHintsProvider:
@@ -24,3 +49,25 @@ class TestHintsProvider:
         assert hints_provider.edifact_format == EdifactFormat.UTILMD
         assert hints_provider.edifact_format_version == EdifactFormatVersion.FV2104
         assert await hints_provider.get_hint_text("583") == "[583] Hinweis: Verwendung der ID der Marktlokation"
+
+    async def test_concurrent_hint_text_resolving(self):
+        """
+        Tests that the get_hint_text methods are evaluated concurrently
+        :return:
+        """
+        hints_provider = Dummy1sHintsProvider()
+        dummy_keys = ["1", "2", "3"]
+        start = datetime.datetime.now()
+        await hints_provider.get_hints(dummy_keys)
+        end = datetime.datetime.now()
+        assert (end - start).total_seconds() < len(dummy_keys)
+
+    async def test_sync_hint_text_resolving(self):
+        hints_provider = DummySyncHintsProvider()
+        dummy_keys = ["1", "2", "3"]
+        await hints_provider.get_hints(dummy_keys)
+
+    async def test_async_hint_text_resolving(self):
+        hints_provider = DummyAsyncHintsProvider()
+        dummy_keys = ["1", "2", "3"]
+        await hints_provider.get_hints(dummy_keys)

--- a/unittests/test_mixed_sync_async_rc_fc_evaluation.py
+++ b/unittests/test_mixed_sync_async_rc_fc_evaluation.py
@@ -1,0 +1,61 @@
+"""
+Tests that the code can handle RC/FC evaluators that have both async and sync methods.
+"""
+from unittest import mock
+
+import inject
+import pytest  # type:ignore[import]
+
+from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
+from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
+from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator, RcEvaluator
+from ahbicht.edifact import EdifactFormat, EdifactFormatVersion
+from ahbicht.expressions.ahb_expression_evaluation import evaluate_ahb_expression_tree
+from ahbicht.expressions.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint
+from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
+from ahbicht.expressions.hints_provider import DictBasedHintsProvider, HintsProvider
+
+pytestmark = pytest.mark.asyncio
+
+
+class MixedSyncAsyncRcEvaluator(RcEvaluator):
+    """An RC evaluator that has both sync and async methods"""
+
+    edifact_format = EdifactFormat.UTILMD
+    edifact_format_version = EdifactFormatVersion.FV2104
+
+    def _get_default_context(self):
+        return None  # type:ignore[return-value]
+
+    def evaluate_1(self, _):
+        return ConditionFulfilledValue.FULFILLED
+
+    async def evaluate_2(self, _):
+        return ConditionFulfilledValue.UNFULFILLED
+
+
+class MixedSyncAsyncFcEvaluator(FcEvaluator):
+    """An FC Evaluator that has both sync and async methods"""
+
+    edifact_format = EdifactFormat.UTILMD
+    edifact_format_version = EdifactFormatVersion.FV2104
+
+    def evaluate_901(self, _):
+        return EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)
+
+    async def evaluate_902(self, _):
+        return EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)
+
+
+class TestMixedSyncAsyncEvaluation:
+    async def test_mixed_async_non_async(self):
+        inject.clear_and_configure(
+            lambda binder: binder.bind(RcEvaluator, MixedSyncAsyncRcEvaluator(EvaluatableData(edifact_seed={})))
+            .bind(FcEvaluator, MixedSyncAsyncFcEvaluator())
+            .bind(HintsProvider, DictBasedHintsProvider({}))
+        )
+        evaluation_input = "something has to be here but it's not important what"
+        tree = parse_expression_including_unresolved_subexpressions("Muss ([1] X [2])[901][902]")
+        evaluation_result = await evaluate_ahb_expression_tree(tree, entered_input=evaluation_input)
+        assert evaluation_result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is True
+        assert evaluation_result.format_constraint_evaluation_result.format_constraints_fulfilled is True

--- a/unittests/test_requirement_constraint_evaluation.py
+++ b/unittests/test_requirement_constraint_evaluation.py
@@ -17,6 +17,8 @@ from ahbicht.expressions.condition_nodes import (
 from ahbicht.expressions.hints_provider import HintsProvider
 from ahbicht.expressions.requirement_constraint_expression_evaluation import requirement_constraint_evaluation
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestRequirementConstraintEvaluation:
     """Test for the evaluation of the condition expression regarding the requirement constraints."""
@@ -62,7 +64,7 @@ class TestRequirementConstraintEvaluation:
             pytest.param("[503]U[504]", True, False, None, "[503] Hinweis:foo und [504] Hinweis:bar"),
         ],
     )
-    def test_evaluate_valid_ahb_expression(
+    async def test_evaluate_valid_ahb_expression(
         self,
         mocker,
         condition_expression,
@@ -80,7 +82,7 @@ class TestRequirementConstraintEvaluation:
             "ahbicht.expressions.requirement_constraint_expression_evaluation.ConditionNodeBuilder.requirement_content_evaluation_for_all_condition_keys",
             return_value=self._input_values,
         )
-        requirement_constraint_evaluation_result = requirement_constraint_evaluation(
+        requirement_constraint_evaluation_result = await requirement_constraint_evaluation(
             condition_expression=condition_expression
         )
 
@@ -142,7 +144,7 @@ class TestRequirementConstraintEvaluation:
             ),
         ],
     )
-    def test_evaluate_condition_expression_with_invalid_values(
+    async def test_evaluate_condition_expression_with_invalid_values(
         self,
         mocker,
         condition_expression: str,
@@ -157,6 +159,6 @@ class TestRequirementConstraintEvaluation:
             return_value=input_values,
         )
         with pytest.raises(expected_error) as excinfo:
-            requirement_constraint_evaluation(condition_expression)
+            await requirement_constraint_evaluation(condition_expression)
 
         assert expected_error_message in str(excinfo.value)

--- a/unittests/test_utility_functions.py
+++ b/unittests/test_utility_functions.py
@@ -1,0 +1,38 @@
+"""
+Tests the utility functions.
+"""
+from typing import Awaitable, List, TypeVar, Union
+
+import pytest  # type:ignore[import]
+
+from ahbicht.utility_functions import gather_if_necessary
+
+pytestmark = pytest.mark.asyncio
+
+T = TypeVar("T")
+
+
+async def _return_awaitable(arg: T) -> T:
+    """returns the argument but is awaitable"""
+    return arg
+
+
+class TestUtilityFunctions:
+    @pytest.mark.parametrize(
+        "mixed_input, expected_result",
+        [
+            # only non-awaitables
+            pytest.param([], []),
+            pytest.param([3, 2, 1], [3, 2, 1]),
+            pytest.param(["a", "b", "c"], ["a", "b", "c"]),
+            # both awaitables and non-awaitables
+            pytest.param(
+                ["2", _return_awaitable("3"), "4", "foo", _return_awaitable("bar")], ["2", "3", "4", "foo", "bar"]
+            ),
+            # only awaitables
+            pytest.param([_return_awaitable("a"), _return_awaitable("b")], ["a", "b"]),
+        ],
+    )
+    async def test_gather_if_necessary(self, mixed_input: List[Union[T, Awaitable[T]]], expected_result: List[T]):
+        actual = await gather_if_necessary(mixed_input)
+        assert actual == expected_result


### PR DESCRIPTION
The sections that looked like
```python
loop = asyncio.new_event_loop()
asyncio.set_event_loop(loop)
evaluated_foo: dict = loop.run_until_complete(async_evaluate_foo)
```
were [hard to explain](https://pep20.org/#hard) and probably a workaround to a problem that we would have avoided if we made it right from day 1 ;) I know it's my fault/code that caused this code from popping up after all.
In https://github.com/lark-parser/lark/issues/1062 it was clarified that Transformer methods must not be async. So we clearly violated lark API principles when we used the above code snippet to hide actually async code in sync content evaluation methods inside the transformers.
This PR:
- removes any event loop code
- makes methods async that require async execution
- lets transformer method return `Awaitable[X]` instead of `X` where necessary. The actual awaiting then takes places outside the transformer.
- allows the FC/RC `evaluate_<condition_key>` methods to be either sync or async (even mixed)