### PR TITLE
⚙️ Use token to publish new package versions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,11 +5,12 @@ name: Upload Python Package
 
 on:
   release:
-    branches: master
+    branches: main
     types: [created, edited]
 
 jobs:
   tests:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -29,8 +30,8 @@ jobs:
         run: |
           tox
 
-  deploy:
-    if: startsWith(github.ref, 'refs/tags/v')
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     needs: tests
     steps:
@@ -38,16 +39,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9.x"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools setuptools-scm wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build a binary wheel and a source tarball
         run: |
           python setup.py sdist bdist_wheel
-          twine check dist/*
-          twine upload dist/*
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Got the following mail from PyPI

> What?
> 
> During your recent upload or upload attempt to PyPI, we noticed you used basic authentication (username & password). However, your account as two-factor authentication (2FA) enabled.
> 
> In the near future, PyPI will begin prohibiting uploads using basic authentication for accounts with two-factor authentication enabled. Instead, we will require API tokens to be used instead.
> 
> What should I do?
> 
> First, generate an API token for your account or project at https://pypi.org/manage/account/token/. Then, use this token when publishing instead of your username and password. See https://pypi.org/help/#apitoken for help using API tokens to publish.

So this PR introduces API token authentication 

Copy pasted this workflow from our latest and greatest python package Maus 🐭
I added also a token into the repository secrets.