### PR TITLE
🌳Make Concise Tree even more concise

### DIFF
--- a/src/ahbicht/json_serialization/concise_condition_key_tree_schema.py
+++ b/src/ahbicht/json_serialization/concise_condition_key_tree_schema.py
@@ -35,6 +35,15 @@ def _compress_condition_keys_only(data: dict) -> dict:
     """
     # this has been found heuristically. There's no way to explain it, just follow the test cases.
     # there's probably a much easier way, e.g. by using a separate token schema.
+    if (
+        "tree" in data
+        and "type" in data["tree"]
+        and data["tree"]["type"] == "single_requirement_indicator_expression"
+        and data["tree"]["children"][0]["token"]["type"] == "MODAL_MARK"
+    ):
+        modal_mark = data["tree"]["children"][0]["token"]["value"]
+        del data["tree"]["children"][0]
+        data["tree"]["type"] = modal_mark
     if "tree" in data and data["tree"] is not None and data["tree"]["type"] == "condition":
         return {
             "token": {"value": data["tree"]["children"][0]["token"]["value"], "type": "condition_key"},

--- a/unittests/test_tree_schemas.py
+++ b/unittests/test_tree_schemas.py
@@ -277,9 +277,8 @@ class TestTreeSchemas:
                         {
                             "token": None,
                             "tree": {
-                                "type": "single_requirement_indicator_expression",
+                                "type": "Muss",
                                 "children": [
-                                    {"token": {"value": "Muss", "type": "MODAL_MARK"}, "tree": None},
                                     {
                                         "token": None,
                                         "tree": {
@@ -337,7 +336,6 @@ class TestTreeSchemas:
                             "token": None,
                             "tree": {
                                 "children": [
-                                    {"token": {"value": "Soll", "type": "MODAL_MARK"}, "tree": None},
                                     {
                                         "token": None,
                                         "tree": {
@@ -427,17 +425,14 @@ class TestTreeSchemas:
                                         },
                                     },
                                 ],
-                                "type": "single_requirement_indicator_expression",
+                                "type": "Soll",
                             },
                         },
                         {
                             "token": None,
                             "tree": {
-                                "children": [
-                                    {"token": {"value": "Kann", "type": "MODAL_MARK"}, "tree": None},
-                                    {"token": {"value": "43", "type": "condition_key"}, "tree": None},
-                                ],
-                                "type": "single_requirement_indicator_expression",
+                                "children": [{"token": {"value": "43", "type": "condition_key"}, "tree": None}],
+                                "type": "Kann",
                             },
                         },
                     ],


### PR DESCRIPTION
Replaces the `type` =`single_requirement_indictor_expression` with its first childs modal mark and remove the first child