### PR TITLE
🐛📦 Add `pytz` to setup.cfg `install_requires`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     marshmallow
     marshmallow_enum
     maus>=0.1.1
+    pytz
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This is a bug that was introduced in #127.
The instructions were clear:
https://github.com/Hochfrequenz/ahbicht/blob/d822e734af4c4e3b03263b471c0744694da84cb5/requirements.in#L8

I just ignored them ;)