### PR TITLE
👁‍🗨Change Visibility of `parse_as_datetime` to "public"

### DIFF
--- a/src/ahbicht/content_evaluation/german_strom_and_gas_tag.py
+++ b/src/ahbicht/content_evaluation/german_strom_and_gas_tag.py
@@ -23,7 +23,7 @@ def _get_german_local_time(date_time: datetime) -> time:
 
 
 # the functions below are excessively unit tested; Please add a test case if you suspect their behaviour to be wrong
-def _parse_as_datetime(entered_input: str) -> Tuple[Optional[datetime], Optional[EvaluatedFormatConstraint]]:
+def parse_as_datetime(entered_input: str) -> Tuple[Optional[datetime], Optional[EvaluatedFormatConstraint]]:
     """
     Try to parse the given entered_input as datetime
     :param entered_input: a string
@@ -57,7 +57,7 @@ def has_no_utc_offset(entered_input: str) -> EvaluatedFormatConstraint:
     This means the UTC offset is exactly "+00:00".
     """
     # the name of the method contains a negation because this it's commonly like this in the BDEW format constraints.
-    date_time, error_result = _parse_as_datetime(entered_input)
+    date_time, error_result = parse_as_datetime(entered_input)
     if error_result is not None:
         return error_result
     original_time = date_time.time()  # type:ignore[union-attr]
@@ -92,7 +92,7 @@ def is_xtag_limit(entered_input: str, division: Union[Literal["Strom"], Literal[
     """
     Tries to parse the entered_input as datetime and checks if it is the start/end of a Strom- or Gastag
     """
-    date_time, error_result = _parse_as_datetime(entered_input)
+    date_time, error_result = parse_as_datetime(entered_input)
     if error_result is not None:
         return error_result
     xtag_evaluator: Callable[[datetime], bool]

--- a/unittests/test_german_strom_and_gas_tag.py
+++ b/unittests/test_german_strom_and_gas_tag.py
@@ -6,10 +6,10 @@ from datetime import datetime, timedelta, timezone
 import pytest  # type:ignore[import]
 
 from ahbicht.content_evaluation.german_strom_and_gas_tag import (
-    _parse_as_datetime,
     berlin,
     is_gastag_limit,
     is_stromtag_limit,
+    parse_as_datetime,
 )
 
 
@@ -26,7 +26,7 @@ class TestGermanStromAndGasTag:
         ],
     )
     def test_successful_parsing(self, dt_string: str, expected_datetime: datetime):
-        actual, error = _parse_as_datetime(dt_string)
+        actual, error = parse_as_datetime(dt_string)
         assert error is None
         assert actual == expected_datetime
 
@@ -40,7 +40,7 @@ class TestGermanStromAndGasTag:
         ],
     )
     def test_errornous_parsing(self, dt_string: str, expected_error_msg: str):
-        actual, error = _parse_as_datetime(dt_string)
+        actual, error = parse_as_datetime(dt_string)
         assert actual is None
         assert error is not None
         assert error.format_constraint_fulfilled is False


### PR DESCRIPTION
because this method can be useful to downstream code