### PR TITLE
pylint: remove `no-self-use`

### DIFF
--- a/src/ahbicht/content_evaluation/categorized_key_extract.py
+++ b/src/ahbicht/content_evaluation/categorized_key_extract.py
@@ -11,7 +11,7 @@ from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluati
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint
 
 
-# pylint: disable=too-few-public-methods, no-self-use, unused-argument
+# pylint: disable=too-few-public-methods,  unused-argument
 @attrs.define(auto_attribs=True)
 class CategorizedKeyExtract:
     """

--- a/src/ahbicht/content_evaluation/content_evaluation_result.py
+++ b/src/ahbicht/content_evaluation/content_evaluation_result.py
@@ -15,7 +15,7 @@ from ahbicht.expressions.condition_nodes import (
 )
 
 
-# pylint: disable=too-few-public-methods, no-self-use, unused-argument
+# pylint: disable=too-few-public-methods, unused-argument
 @attrs.define(auto_attribs=True)
 class ContentEvaluationResult:
     """

--- a/src/ahbicht/content_evaluation/evaluators.py
+++ b/src/ahbicht/content_evaluation/evaluators.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 from maus.edifact import EdifactFormat, EdifactFormatVersion
 
 
-# pylint: disable=no-self-use, too-few-public-methods
+# pylint: disable=too-few-public-methods
 class Evaluator(ABC):
     """
     Base of all evaluators.

--- a/src/ahbicht/content_evaluation/fc_evaluators.py
+++ b/src/ahbicht/content_evaluation/fc_evaluators.py
@@ -17,7 +17,6 @@ from ahbicht.content_evaluation.german_strom_and_gas_tag import has_no_utc_offse
 from ahbicht.expressions.condition_nodes import EvaluatedFormatConstraint
 
 
-# pylint: disable=no-self-use
 class FcEvaluator(Evaluator, ABC):
     """
     Base of all Format Constraint (FC) evaluators.

--- a/src/ahbicht/content_evaluation/rc_evaluators.py
+++ b/src/ahbicht/content_evaluation/rc_evaluators.py
@@ -13,8 +13,6 @@ from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, Eval
 from ahbicht.content_evaluation.evaluators import Evaluator
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue
 
-# pylint: disable=no-self-use
-
 
 class RcEvaluator(Evaluator, ABC):
     """

--- a/src/ahbicht/evaluation_results.py
+++ b/src/ahbicht/evaluation_results.py
@@ -3,7 +3,7 @@ This module contains the classes for the evaluation results.
 A "result" is the outcome of an evaluation. It requires actual data to be present.
 """
 
-# pylint: disable=too-few-public-methods, no-member, no-self-use, unused-argument
+# pylint: disable=too-few-public-methods, no-member,  unused-argument
 from typing import Optional
 
 import attrs

--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -29,8 +29,7 @@ _str_to_modal_mark_mapping: Dict[str, ModalMark] = {
 }
 
 
-# pylint: disable=no-self-use, invalid-name
-# no-self-use: The following methods are not static because it refers to the terminals of the lark grammar.
+# pylint: disable=invalid-name
 # invalid-name: That's also the reason why they seemingly violate the naming conventions.
 class AhbExpressionTransformer(Transformer):
     """

--- a/src/ahbicht/expressions/condition_nodes.py
+++ b/src/ahbicht/expressions/condition_nodes.py
@@ -161,7 +161,7 @@ class EvaluatedFormatConstraintSchema(Schema):
     format_constraint_fulfilled = fields.Boolean(required=True)
     error_message = fields.String(required=False, allow_none=True, dump_default=True)
 
-    # pylint: disable=no-self-use, unused-argument
+    # pylint: disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> EvaluatedFormatConstraint:
         """

--- a/src/ahbicht/expressions/enums.py
+++ b/src/ahbicht/expressions/enums.py
@@ -81,7 +81,7 @@ data element/data element group/segment/segment group at which it is used.
 """
 
 
-# pylint:disable=no-self-use, unused-argument
+# pylint:disable=unused-argument
 class RequirementIndicatorSchema(Schema):
     """
     a helper schema because marshmallow does not support something like fields.Union out of the box

--- a/src/ahbicht/expressions/expression_resolver.py
+++ b/src/ahbicht/expressions/expression_resolver.py
@@ -87,8 +87,7 @@ async def _replace_sub_coroutines_with_awaited_results(tree: Union[Tree, Awaitab
     return result
 
 
-# pylint: disable=no-self-use, invalid-name
-# no-self-use: The following method is not static because it refers to the terminal of the lark grammar.
+# pylint: disable=invalid-name
 # invalid-name: That's also the reason why it seemingly violates the naming conventions.
 class AhbExpressionResolverTransformer(Transformer):
     """
@@ -103,7 +102,7 @@ class AhbExpressionResolverTransformer(Transformer):
         return condition_tree
 
 
-# pylint: disable=no-self-use, invalid-name
+# pylint: disable=invalid-name
 class PackageExpansionTransformer(Transformer):
     """
     The PackageExpansionTransformer expands packages inside a tree to condition expressions by using a PackageResolver.
@@ -142,7 +141,7 @@ class PackageExpansionTransformer(Transformer):
         return tree_result
 
 
-# pylint: disable=no-self-use, invalid-name
+# pylint: disable=invalid-name
 class TimeConditionTransformer(Transformer):
     """
     The TimeConditionEvaluator replaces "time conditions" (aka "UB1", "UB2", "UB3") with evaluatable format constraints.

--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -20,7 +20,6 @@ from ahbicht.expressions.condition_nodes import EvaluatedFormatConstraint
 from ahbicht.expressions.expression_builder import FormatErrorMessageExpressionBuilder
 
 
-# pylint: disable=no-self-use
 @v_args(inline=True)  # Children are provided as *args instead of a list argument
 # pylint:disable=inherit-non-class
 class FormatConstraintTransformer(BaseTransformer[EvaluatedFormatConstraint, EvaluatedFormatConstraint]):

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -27,7 +27,6 @@ from ahbicht.expressions.condition_nodes import (
 from ahbicht.expressions.expression_builder import FormatConstraintExpressionBuilder, HintExpressionBuilder
 
 
-# pylint: disable=no-self-use
 @v_args(inline=True)  # Children are provided as *args instead of a list argument
 # pylint:disable=inherit-non-class
 class RequirementConstraintTransformer(BaseTransformer[TRCTransformerArgument, EvaluatedComposition]):

--- a/src/ahbicht/json_serialization/concise_condition_key_tree_schema.py
+++ b/src/ahbicht/json_serialization/concise_condition_key_tree_schema.py
@@ -13,7 +13,7 @@ class ConciseConditionKeyTreeSchema(TreeSchema):
     (not deserialization)
     """
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_dump
     def serialize(self, data, **kwargs) -> dict:
         """

--- a/src/ahbicht/json_serialization/concise_tree_schema.py
+++ b/src/ahbicht/json_serialization/concise_tree_schema.py
@@ -14,7 +14,7 @@ class ConciseTreeSchema(TreeSchema):
     (not deserialization)
     """
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_dump
     def serialize(self, data, **kwargs) -> dict:
         """

--- a/src/ahbicht/json_serialization/tree_schema.py
+++ b/src/ahbicht/json_serialization/tree_schema.py
@@ -9,7 +9,7 @@ from marshmallow import Schema, fields, post_load, pre_dump
 
 # in the classes/schemata we don't care about if there aren't enough public versions.
 # We also don't care about unused kwargs, or no self-use.
-# pylint: disable=too-few-public-methods,unused-argument,no-self-use
+# pylint: disable=too-few-public-methods,unused-argument
 
 
 class _TokenOrTree:

--- a/src/ahbicht/mapping_results.py
+++ b/src/ahbicht/mapping_results.py
@@ -39,7 +39,7 @@ class ConditionKeyConditionTextMappingSchema(Schema):
     condition_key = fields.String()
     condition_text = fields.String(load_default=None)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> ConditionKeyConditionTextMapping:
         """
@@ -82,7 +82,7 @@ class PackageKeyConditionExpressionMappingSchema(Schema):
     package_key = fields.String()
     package_expression = fields.String(load_default=None)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> PackageKeyConditionExpressionMapping:
         """

--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -9,7 +9,7 @@ from marshmallow_enum import EnumField  # type:ignore[import]
 
 from ahbicht.validation.validation_values import RequirementValidationValue
 
-# pylint: disable=too-few-public-methods, no-member, no-self-use, unused-argument
+# pylint: disable=too-few-public-methods, no-member, unused-argument
 
 
 @attrs.define(auto_attribs=True, kw_only=True)
@@ -127,7 +127,7 @@ class ValidationResultInContextSchema(Schema):
     discriminator = fields.String()
     validation_result = fields.Nested(ValidationResultSchema)
 
-    # pylint:disable=unused-argument,no-self-use
+    # pylint:disable=unused-argument
     @post_load
     def deserialize(self, data, **kwargs) -> ValidationResultInContext:
         """

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -25,8 +25,6 @@ class DummyFcEvaluator(FcEvaluator):
     edifact_format = EdifactFormat.UTILMD
     edifact_format_version = EdifactFormatVersion.FV2104
 
-    # no-self-use: The following methods are not static because it refers to the terminals of the lark grammar.
-
     async def evaluate_950(self, entered_input: str) -> EvaluatedFormatConstraint:
         """
         [950] Format: Marktlokations-ID


### PR DESCRIPTION
the message is no longer part of standard pylint.

see release notes: https://github.com/PyCQA/pylint/blob/214201a07aef7068013ff3af1c3cbd479ac39146/doc/whatsnew/2/2.14/summary.rst

> We removed no-init and made no-self-use optional as they were too opinionated.

Fixes:
> E0012: Bad option value for disable. Don't recognize message no-self-use. (bad-option-value)