### PR TITLE
🔉 Raise error with meaningful message when trying to use `inject.attr`

### DIFF
--- a/unittests/test_integration_mwe.py
+++ b/unittests/test_integration_mwe.py
@@ -27,7 +27,23 @@ from unittests.defaults import (
 pytestmark = pytest.mark.asyncio
 
 
+class SomethingInjectable:
+    """
+    This class is used by one of our custom Evaluators.
+    The evaluators a bit fragile because of https://github.com/ivankorobkov/python-inject/issues/77
+    This means you _cannot_ use inject.attr(...) in your custom evaluators
+    """
+
+    pass
+
+
+class MweRcEvaluatorThatUsesInjectAttr(EmptyDefaultRcEvaluator):
+    something_injectable = inject.attr(SomethingInjectable)  # this won't work and the test proves it
+
+
 class MweRcEvaluator(EmptyDefaultRcEvaluator):
+    # do _not_use inject.attr! It breaks in the inspection inside the Evaluator __init__ method
+
     def evaluate_1(self, evaluatable_data, context):
         seed = evaluatable_data.edifact_seed
         if "foo" in seed and seed["foo"] == "bar":
@@ -42,6 +58,8 @@ class MweRcEvaluator(EmptyDefaultRcEvaluator):
         return ConditionFulfilledValue.UNFULFILLED
 
     def evaluate_3(self, _, __):
+        something_injected = inject.instance(SomethingInjectable)  # this is fine (other than inject.attr, see above)
+        assert isinstance(something_injected, SomethingInjectable)
         return ConditionFulfilledValue.UNFULFILLED
 
 

--- a/unittests/test_integration_mwe.py
+++ b/unittests/test_integration_mwe.py
@@ -37,10 +37,6 @@ class SomethingInjectable:
     pass
 
 
-class MweRcEvaluatorThatUsesInjectAttr(EmptyDefaultRcEvaluator):
-    something_injectable = inject.attr(SomethingInjectable)  # this won't work and the test proves it
-
-
 class MweRcEvaluator(EmptyDefaultRcEvaluator):
     # do _not_use inject.attr! It breaks in the inspection inside the Evaluator __init__ method
 

--- a/unittests/test_warning_when_using_inject_attr.py
+++ b/unittests/test_warning_when_using_inject_attr.py
@@ -1,6 +1,6 @@
 import inject
 import pytest  # type:ignore[import]
-import pytest_asyncio
+import pytest_asyncio  # type:ignore[import]
 
 from unittests.defaults import EmptyDefaultRcEvaluator
 

--- a/unittests/test_warning_when_using_inject_attr.py
+++ b/unittests/test_warning_when_using_inject_attr.py
@@ -1,0 +1,39 @@
+import inject
+import pytest  # type:ignore[import]
+import pytest_asyncio
+
+from unittests.defaults import EmptyDefaultRcEvaluator
+
+
+class SomethingInjectable:
+    """
+    This class is used by the custom Evaluators below
+    """
+
+
+class RcEvaluatorThatUsesInjectAttr(EmptyDefaultRcEvaluator):
+    something_injectable = inject.attr(SomethingInjectable)  # this won't work and the test proves it
+
+
+class TestErrorWhenUsingInjectAttr:
+    """
+    Asserts on a specific error message when a library user tries to use inject.attr
+    """
+
+    @pytest_asyncio.fixture()
+    def clear_injectors(self):
+        # This might not be necessary when you only run this test alone but without this fixture
+        # running all the tests (e.g. via tox) might fail
+        inject.clear()
+
+    def test_attribute_error_with_inject_attr(self, clear_injectors):
+        """
+        This tests that an error with a meaningful error message is raised.
+        Test can be removed as soon as the underlying bug in inject is resolved.
+        """
+        with pytest.raises(AttributeError) as attribute_error:
+            RcEvaluatorThatUsesInjectAttr()
+        assert (
+            "Using inject.attr in custom evaluators as you tried in RcEvaluatorThatUsesInjectAttr is not supported."
+            in str(attribute_error)
+        )


### PR DESCRIPTION
instead directly exposing the inject error to the ahbicht user who might not be aware of the underlying problem in https://github.com/ivankorobkov/python-inject/issues/77