### PR TITLE
🚀 Add cache to parsing calls

### DIFF
--- a/src/ahbicht/expressions/ahb_expression_parser.py
+++ b/src/ahbicht/expressions/ahb_expression_parser.py
@@ -4,6 +4,7 @@ using the parsing library lark: https://lark-parser.readthedocs.io/en/latest/
 The goal is to separate the requirement indicator (i.e. Muss, Soll, Kann, X, O, U) from the condition expression
 and also several modal marks expressions if there are more than one.
 """
+from typing import Dict
 
 from lark import Lark, Token, Tree
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF
@@ -26,8 +27,12 @@ CONDITION_EXPRESSION: /(?!\BU\B)[\[\]\(\)U∧O∨X⊻\d\sP\.UB]+/i
 # and CTRL+F for "Mus[2]" in the unittest that fails if you remove the lookahead.
 _parser = Lark(GRAMMAR, start="ahb_expression")
 
+_cache: Dict[str, Tree[Token]] = {}  #: holds the ahb expression as key and the parsed Tree as value
 
-def parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression: str) -> Tree[Token]:
+
+def parse_ahb_expression_to_single_requirement_indicator_expressions(
+    ahb_expression: str, disable_cache: bool = False
+) -> Tree[Token]:
     """
     Parse a given expression as it appears in the AHB with the help of the here defined grammar to a lark tree.
     The goal is to separate the requirement indicator (i.e. Muss/M Soll/S Kann/K, X, O, U) from the condition expression
@@ -35,10 +40,14 @@ def parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_express
     Whitespaces are ignored.
 
     :param ahb_expression: e.g. 'Muss[45]U[52] Soll[1]'
+    :param disable_cache: set to true to disable caching
     :return parsed_tree:
     """
+    if (not disable_cache) and ahb_expression in _cache:
+        return _cache[ahb_expression]
     try:
         parsed_tree = _parser.parse(ahb_expression)
+        _cache.update({ahb_expression: parsed_tree})
     except (UnexpectedEOF, UnexpectedCharacters, TypeError) as eof:
         raise SyntaxError(
             """Please make sure that the ahb_expression starts with a requirement indicator \

--- a/unittests/test_caching.py
+++ b/unittests/test_caching.py
@@ -1,0 +1,82 @@
+import asyncio
+import timeit
+
+import pytest  # type:ignore[import]
+import pytest_asyncio  # type:ignore[import]
+
+from ahbicht.expressions.ahb_expression_parser import _parser as ahb_expr_parser
+from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
+from ahbicht.expressions.condition_expression_parser import _parser as cond_expr_parser
+from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
+
+
+class TestCaching:
+    """
+    Tests the caching capabilities of both ahb and condition expression parsers
+    """
+
+    # test expressions have to be unique per test case because the tests interfere (they share the same "global" cache)
+
+    def test_ahb_expression_cache_performance(self):
+        # be careful with performance tests. they naturally behave different on different systems
+        ahb_expression = "Muss [7] U [8]"
+        calls = 1000
+        time_with_cache = timeit.timeit(
+            lambda: parse_ahb_expression_to_single_requirement_indicator_expressions(
+                ahb_expression, disable_cache=False
+            ),
+            number=calls,
+        )
+        time_without_cache = timeit.timeit(
+            lambda: parse_ahb_expression_to_single_requirement_indicator_expressions(
+                ahb_expression, disable_cache=True
+            ),
+            number=calls,
+        )
+        # a 100-fold performance improvement for 1000 calls of a simple expression seems fair
+        assert time_with_cache < time_without_cache / 100
+
+    def test_ahb_expression_cache_disabled(self, mocker):
+        ahb_expression = "Muss [1] U [2]"
+        parse_spy = mocker.spy(ahb_expr_parser, "parse")
+        for _ in range(100):
+            _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression, disable_cache=True)
+        assert parse_spy.call_count == 100
+
+    def test_ahb_expression_cache_sync(self, mocker):
+        ahb_expression = "Muss [3] U [4]"
+        parse_spy = mocker.spy(ahb_expr_parser, "parse")
+        for _ in range(100):
+            _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
+        parse_spy.assert_called_once_with(ahb_expression)
+
+    async def test_ahb_expression_cache_async(self, mocker):
+
+        ahb_expression = "Muss [5] U [6]"
+        parse_spy = mocker.spy(ahb_expr_parser, "parse")
+
+        async def parsing_task():
+            parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
+
+        tasks = [parsing_task() for _ in range(100)]
+        await asyncio.gather(*tasks)
+        parse_spy.assert_called_once_with(ahb_expression)
+
+    def test_condition_expression_cache_sync(self, mocker):
+        cond_expression = "[1] U [2]"
+        parse_spy = mocker.spy(cond_expr_parser, "parse")
+        for _ in range(100):
+            _ = parse_condition_expression_to_tree(cond_expression)
+        parse_spy.assert_called_once_with(cond_expression)
+
+    async def test_condition_expression_cache_async(self, mocker):
+        # test expression has to be different from the cond_expression in the sync test case because the tests interfere
+        cond_expression = "[3] U [4]"
+        parse_spy = mocker.spy(cond_expr_parser, "parse")
+
+        async def parsing_task():
+            parse_condition_expression_to_tree(cond_expression)
+
+        tasks = [parsing_task() for _ in range(100)]
+        await asyncio.gather(*tasks)
+        parse_spy.assert_called_once_with(cond_expression)

--- a/unittests/test_caching.py
+++ b/unittests/test_caching.py
@@ -4,8 +4,10 @@ import timeit
 import pytest  # type:ignore[import]
 import pytest_asyncio  # type:ignore[import]
 
+from ahbicht.expressions.ahb_expression_parser import _cache as ahb_expr_cache
 from ahbicht.expressions.ahb_expression_parser import _parser as ahb_expr_parser
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
+from ahbicht.expressions.condition_expression_parser import _cache as cond_expr_cache
 from ahbicht.expressions.condition_expression_parser import _parser as cond_expr_parser
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 
@@ -14,6 +16,11 @@ class TestCaching:
     """
     Tests the caching capabilities of both ahb and condition expression parsers
     """
+
+    @pytest.fixture()
+    def clear_caches(self):
+        ahb_expr_cache.clear()
+        cond_expr_cache.clear()
 
     # test expressions have to be unique per test case because the tests interfere (they share the same "global" cache)
 
@@ -27,7 +34,7 @@ class TestCaching:
             ),
         ],
     )
-    def test_ahb_expression_cache_performance(self, ahb_expression: str):
+    def test_ahb_expression_cache_performance(self, clear_caches, ahb_expression: str):
         # be careful with performance tests. they naturally behave different on different systems
         calls = 1000
         time_with_cache = timeit.timeit(
@@ -49,21 +56,21 @@ class TestCaching:
         # a 100-fold performance improvement for 1000 calls of a simple expression seems fair
         # still, the overall time spent in parsing is not large: the order of magnitude for parsing without cache is 1ms
 
-    def test_ahb_expression_cache_disabled(self, mocker):
+    def test_ahb_expression_cache_disabled(self, clear_caches, mocker):
         ahb_expression = "Muss [1] U [2]"
         parse_spy = mocker.spy(ahb_expr_parser, "parse")
         for _ in range(100):
             _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression, disable_cache=True)
         assert parse_spy.call_count == 100
 
-    def test_ahb_expression_cache_sync(self, mocker):
+    def test_ahb_expression_cache_sync(self, clear_caches, mocker):
         ahb_expression = "Muss [3] U [4]"
         parse_spy = mocker.spy(ahb_expr_parser, "parse")
         for _ in range(100):
             _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
         parse_spy.assert_called_once_with(ahb_expression)
 
-    async def test_ahb_expression_cache_async(self, mocker):
+    async def test_ahb_expression_cache_async(self, clear_caches, mocker):
 
         ahb_expression = "Muss [5] U [6]"
         parse_spy = mocker.spy(ahb_expr_parser, "parse")
@@ -75,14 +82,14 @@ class TestCaching:
         await asyncio.gather(*tasks)
         parse_spy.assert_called_once_with(ahb_expression)
 
-    def test_condition_expression_cache_sync(self, mocker):
+    def test_condition_expression_cache_sync(self, clear_caches, mocker):
         cond_expression = "[1] U [2]"
         parse_spy = mocker.spy(cond_expr_parser, "parse")
         for _ in range(100):
             _ = parse_condition_expression_to_tree(cond_expression)
         parse_spy.assert_called_once_with(cond_expression)
 
-    async def test_condition_expression_cache_async(self, mocker):
+    async def test_condition_expression_cache_async(self, clear_caches, mocker):
         # test expression has to be different from the cond_expression in the sync test case because the tests interfere
         cond_expression = "[3] U [4]"
         parse_spy = mocker.spy(cond_expr_parser, "parse")


### PR DESCRIPTION
Das bringt auf den ersten Blick ganz signifikante _relative_ Performance-Gewinne, wenn man den gleichen Ausdruck immer wieder parsen muss (was in unserem Anwendungsfall ja dem Normalfall entspricht).

Es würde uns auch erlauben alle Bedingungen, die jemals in AHBs vorkommen ein einziges Mal zu parsen und dann zur eigentlichen runtime immer eine O(1) parsing Geschwindigkeit zu haben.

Ich hab in einen Test auch mal ne Größenordnung reingeschrieben. Die _absolute_ Ersparnis auf meinem Rechner ist ungefähr 1ms pro parsing-Vorgang. Das ist jetzt nicht mega viel.

Für ein durchschnittliches AHB würde ich schätzen, dass wir ~50ms einsparen könnten. Also schon ein bisschen was aber wenn wir feststellen, dass uns dadurch irgendwo anders Probleme entstehen, dann würde ich es disablen