### PR TITLE
🐛 Fix usage of python-inject wih `threading.local`

### DIFF
--- a/minimal_working_example.ipynb
+++ b/minimal_working_example.ipynb
@@ -29,12 +29,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Tree(Token('RULE', 'ahb_expression'), [Tree('single_requirement_indicator_expression', [Token('MODAL_MARK', 'Muss'), Tree('and_composition', [Tree('and_composition', [Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '2')]), Tree('then_also_composition', [Tree('and_composition', [Tree('or_composition', [Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '3')]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '4')])]), Tree(Token('RULE', 'package'), [Token('PACKAGE_KEY', '123P')])]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '901')])])]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '555')])])])])\n"
+      "Tree(Token('RULE', 'ahb_expression'), [Tree('single_requirement_indicator_expression', [Token('MODAL_MARK', 'Muss'), Tree('and_composition', [Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '2')]), Tree('and_composition', [Tree('then_also_composition', [Tree('and_composition', [Tree('or_composition', [Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '3')]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '4')])]), Tree(Token('RULE', 'package'), [Token('PACKAGE_KEY', '123P')])]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '901')])]), Tree(Token('RULE', 'condition'), [Token('CONDITION_KEY', '555')])])])])])\n"
      ]
     },
     {
      "data": {
-      "text/plain": "{'type': 'ahb_expression',\n 'children': [{'tree': {'type': 'single_requirement_indicator_expression',\n    'children': [{'tree': None,\n      'token': {'value': 'Muss', 'type': 'MODAL_MARK'}},\n     {'tree': {'type': 'and_composition',\n       'children': [{'tree': {'type': 'and_composition',\n          'children': [{'tree': {'type': 'condition',\n             'children': [{'tree': None,\n               'token': {'value': '2', 'type': 'CONDITION_KEY'}}]},\n            'token': None},\n           {'tree': {'type': 'then_also_composition',\n             'children': [{'tree': {'type': 'and_composition',\n                'children': [{'tree': {'type': 'or_composition',\n                   'children': [{'tree': {'type': 'condition',\n                      'children': [{'tree': None,\n                        'token': {'value': '3', 'type': 'CONDITION_KEY'}}]},\n                     'token': None},\n                    {'tree': {'type': 'condition',\n                      'children': [{'tree': None,\n                        'token': {'value': '4', 'type': 'CONDITION_KEY'}}]},\n                     'token': None}]},\n                  'token': None},\n                 {'tree': {'type': 'package',\n                   'children': [{'tree': None,\n                     'token': {'value': '123P', 'type': 'PACKAGE_KEY'}}]},\n                  'token': None}]},\n               'token': None},\n              {'tree': {'type': 'condition',\n                'children': [{'tree': None,\n                  'token': {'value': '901', 'type': 'CONDITION_KEY'}}]},\n               'token': None}]},\n            'token': None}]},\n         'token': None},\n        {'tree': {'type': 'condition',\n          'children': [{'tree': None,\n            'token': {'value': '555', 'type': 'CONDITION_KEY'}}]},\n         'token': None}]},\n      'token': None}]},\n   'token': None}]}"
+      "text/plain": "{'type': 'ahb_expression',\n 'children': [{'tree': {'type': 'single_requirement_indicator_expression',\n    'children': [{'tree': None,\n      'token': {'value': 'Muss', 'type': 'MODAL_MARK'}},\n     {'tree': {'type': 'and_composition',\n       'children': [{'tree': {'type': 'condition',\n          'children': [{'tree': None,\n            'token': {'value': '2', 'type': 'CONDITION_KEY'}}]},\n         'token': None},\n        {'tree': {'type': 'and_composition',\n          'children': [{'tree': {'type': 'then_also_composition',\n             'children': [{'tree': {'type': 'and_composition',\n                'children': [{'tree': {'type': 'or_composition',\n                   'children': [{'tree': {'type': 'condition',\n                      'children': [{'tree': None,\n                        'token': {'value': '3', 'type': 'CONDITION_KEY'}}]},\n                     'token': None},\n                    {'tree': {'type': 'condition',\n                      'children': [{'tree': None,\n                        'token': {'value': '4', 'type': 'CONDITION_KEY'}}]},\n                     'token': None}]},\n                  'token': None},\n                 {'tree': {'type': 'package',\n                   'children': [{'tree': None,\n                     'token': {'value': '123P', 'type': 'PACKAGE_KEY'}}]},\n                  'token': None}]},\n               'token': None},\n              {'tree': {'type': 'condition',\n                'children': [{'tree': None,\n                  'token': {'value': '901', 'type': 'CONDITION_KEY'}}]},\n               'token': None}]},\n            'token': None},\n           {'tree': {'type': 'condition',\n             'children': [{'tree': None,\n               'token': {'value': '555', 'type': 'CONDITION_KEY'}}]},\n            'token': None}]},\n         'token': None}]},\n      'token': None}]},\n   'token': None}]}"
      },
      "execution_count": 2,
      "metadata": {},
@@ -68,7 +68,7 @@
    "outputs": [
     {
      "data": {
-      "text/plain": "{'ahb_expression': [{'single_requirement_indicator_expression': ['Muss',\n    {'and_composition': [{'and_composition': ['2',\n        {'then_also_composition': [{'and_composition': [{'or_composition': ['3',\n              '4']},\n            '123P']},\n          '901']}]},\n      '555']}]}]}"
+      "text/plain": "{'ahb_expression': [{'single_requirement_indicator_expression': ['Muss',\n    {'and_composition': ['2',\n      {'and_composition': [{'then_also_composition': [{'and_composition': [{'or_composition': ['3',\n              '4']},\n            '123P']},\n          '901']},\n        '555']}]}]}]}"
      },
      "execution_count": 3,
      "metadata": {},
@@ -298,17 +298,12 @@
    "source": [
     "from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider, TokenLogicProvider\n",
     "import inject\n",
-    "from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider\n",
+    "from ahbicht.content_evaluation.evaluationdatatypes import (\n",
+    "    EvaluatableDataProvider,\n",
+    "    get_thread_local_evaluatable_data,\n",
+    "    set_thread_local_evaluatable_data,\n",
+    ")\n",
     "from ahbicht.expressions.ahb_expression_evaluation import evaluate_ahb_expression_tree\n",
-    "\n",
-    "# We use dependency injection to get the evaluators in place:\n",
-    "def provide_evaluatable_data():\n",
-    "    # place your own dynamic(!) data provision method here\n",
-    "    return EvaluatableData(\n",
-    "        edifact_seed=hardcoded_content_evaluations,\n",
-    "        edifact_format=EdifactFormat.UTILMD,\n",
-    "        edifact_format_version=EdifactFormatVersion.FV2104,\n",
-    "    )\n",
     "\n",
     "\n",
     "# a token logic provider is a wrapper around all evaluator instance singletons\n",
@@ -318,8 +313,17 @@
     "inject.clear_and_configure(\n",
     "    lambda binder: binder.bind(TokenLogicProvider, my_logic_provider)\n",
     "    # While the evaluators are injected as singleton style instances, the evaluatable data may change in each call.\n",
-    "    # This is why they are injected with \"bind_to_provider\" instead of a simple \"bind\".\n",
-    "    .bind_to_provider(EvaluatableDataProvider, provide_evaluatable_data)\n",
+    "    # This is why they are injected with \"bind_to_provider\" instead of a simple \"bind\"\n",
+    "    # get_thread_local_evaluatable_data is a predefined method in ahbicht that contains thread local evaluatable data\n",
+    "    .bind_to_provider(EvaluatableDataProvider, get_thread_local_evaluatable_data)\n",
+    ")\n",
+    "\n",
+    "set_thread_local_evaluatable_data(\n",
+    "    EvaluatableData(\n",
+    "        edifact_seed=hardcoded_content_evaluations,\n",
+    "        edifact_format=EdifactFormat.UTILMD,\n",
+    "        edifact_format_version=EdifactFormatVersion.FV2104,\n",
+    "    )\n",
     ")\n",
     "\n",
     "# now that we injected the package resolver, we can also expand the package 123P in the expression\n",
@@ -409,7 +413,7 @@
     ")\n",
     "create_and_inject_hardcoded_evaluators(\n",
     "    content_evaluation_result,\n",
-    "    evaluatable_data_provider=provide_evaluatable_data,\n",
+    "    evaluatable_data_provider=get_thread_local_evaluatable_data,\n",
     "    edifact_format=EdifactFormat.UTILMD,\n",
     "    edifact_format_version=EdifactFormatVersion.FV2104,\n",
     ")  # this does all the magic, no need to manually define classes\n",
@@ -490,7 +494,7 @@
     "for content_evaluation_result in precalculated_results:\n",
     "    create_and_inject_hardcoded_evaluators(\n",
     "        content_evaluation_result,\n",
-    "        evaluatable_data_provider=provide_evaluatable_data,\n",
+    "        evaluatable_data_provider=get_thread_local_evaluatable_data,\n",
     "        edifact_format=EdifactFormat.UTILMD,\n",
     "        edifact_format_version=EdifactFormatVersion.FV2104,\n",
     "    )\n",

--- a/src/ahbicht/content_evaluation/evaluator_factory.py
+++ b/src/ahbicht/content_evaluation/evaluator_factory.py
@@ -72,4 +72,4 @@ def create_and_inject_hardcoded_evaluators(
         if evaluatable_data_provider is not None:
             binder.bind_to_provider(EvaluatableDataProvider, evaluatable_data_provider)
 
-    inject.clear_and_configure(configure)
+    inject.configure_once(configure)


### PR DESCRIPTION
I asked in the python-inject repo how to combine "global" injectors (for the RC/FC Evaluators+Resolvers) with "local" injectors (for the evaluatable data). https://github.com/ivankorobkov/python-inject/issues/84

This PR adjusts ahbicht to obey the rules of python-inject:
- only configure the injection once
- don't use `clear_and_configure` outside the tests
- instead of clearing the configuration every time new evaluatable data are injected use `thread.local` https://docs.python.org/3/library/threading.html#thread-local-data
- this affects the full MWE in the integration test and the example in the jupyter notebook (https://github.com/Hochfrequenz/ahbicht/blob/injection_fun/minimal_working_example.ipynb)