### PR TITLE
📦🐛use python 3.10 in package publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The python publish workflow runs the type check in python 3.9 which [doesn't work](https://github.com/Hochfrequenz/ahbicht/pull/194/files#r911954962) with the changes from #194.

The easiest fix is to run the checks before publishing in 3.10.

https://github.com/Hochfrequenz/ahbicht/actions/runs/2596809649

> type_check run-test: commands[0] | mypy --show-error-codes src/ahbicht
src/ahbicht/condition_node_builder.py:101: error: "AttributeError" has no attribute "name"  [attr-defined]
Found 1 error in 1 file (checked 37 source files)