### PR TITLE
WB-BE_455: Fix dumping of ValidationResultInContext 

### DIFF
--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -26,13 +26,19 @@ class ValidationResult(ABC):
     )
 
 
-class ValidationResultSchema(Schema):
+class ValidationResultAttributesSchema(Schema):
     """
-    A schema to (de-)serialize ValidationResult
+    A schema to pass on the attributes of ValidationResult
     """
 
     requirement_validation = EnumField(RequirementValidationValue)
     hints = fields.String(load_default=None)
+
+
+class ValidationResultSchema(ValidationResultAttributesSchema):
+    """
+    A schema to (de-)serialize ValidationResult
+    """
 
     @post_load
     def deserialize(self, data, **kwargs) -> ValidationResult:
@@ -44,13 +50,27 @@ class ValidationResultSchema(Schema):
         """
         return ValidationResult(**data)
 
+    def dump(self, data, **kwargs) -> str:
+        """
+        A way to dump the subclasses DataElementValidationResult and SegmentLevelValidationResult
+        of ValidationResult
+        :param data:
+        :param kwargs:
+        :return:
+        """
+        if isinstance(data, DataElementValidationResult):
+            return DataElementValidationResultSchema().dump(data)
+        elif isinstance(data, SegmentLevelValidationResult):
+            return SegmentLevelValidationResultSchema().dump(data)
+        raise NotImplementedError(f"Data type of {data} is not implemented for JSON serialization")
+
 
 @attrs.define(auto_attribs=True, kw_only=True)
 class SegmentLevelValidationResult(ValidationResult):
     """Result of the validation of a segment or segment group"""
 
 
-class SegmentLevelValidationResultSchema(ValidationResultSchema):
+class SegmentLevelValidationResultSchema(ValidationResultAttributesSchema):
     """
     A schema to (de-)serialize SegmentLevelValidationResult
     """
@@ -89,7 +109,7 @@ class DataElementValidationResult(ValidationResult):
     )
 
 
-class DataElementValidationResultSchema(ValidationResultSchema):
+class DataElementValidationResultSchema(ValidationResultAttributesSchema):
     """
     A schema to (de-)serialize DataElementValidationResult
     """

--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -1,7 +1,7 @@
 "This module contains the classes for the validation results."
 
 from abc import ABC
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import attrs
 from marshmallow import Schema, fields, post_load
@@ -50,7 +50,7 @@ class ValidationResultSchema(ValidationResultAttributesSchema):
         """
         return ValidationResult(**data)
 
-    def dump(self, obj, **kwargs) -> (Any | list):
+    def dump(self, obj, **kwargs) -> Union[Any, list]:
         """
         A way to dump the subclasses DataElementValidationResult and SegmentLevelValidationResult
         of ValidationResult

--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -1,7 +1,7 @@
 "This module contains the classes for the validation results."
 
 from abc import ABC
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import attrs
 from marshmallow import Schema, fields, post_load
@@ -50,19 +50,19 @@ class ValidationResultSchema(ValidationResultAttributesSchema):
         """
         return ValidationResult(**data)
 
-    def dump(self, data, **kwargs) -> str:
+    def dump(self, obj, **kwargs) -> (Any | list):
         """
         A way to dump the subclasses DataElementValidationResult and SegmentLevelValidationResult
         of ValidationResult
-        :param data:
+        :param obj:
         :param kwargs:
         :return:
         """
-        if isinstance(data, DataElementValidationResult):
-            return DataElementValidationResultSchema().dump(data)
-        elif isinstance(data, SegmentLevelValidationResult):
-            return SegmentLevelValidationResultSchema().dump(data)
-        raise NotImplementedError(f"Data type of {data} is not implemented for JSON serialization")
+        if isinstance(obj, DataElementValidationResult):
+            return DataElementValidationResultSchema().dump(obj)
+        if isinstance(obj, SegmentLevelValidationResult):
+            return SegmentLevelValidationResultSchema().dump(obj)
+        raise NotImplementedError(f"Data type of {obj} is not implemented for JSON serialization")
 
 
 @attrs.define(auto_attribs=True, kw_only=True)

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -351,6 +351,27 @@ class TestJsonSerialization:
                     },
                 },
             ),
+            pytest.param(
+                ValidationResultInContext(
+                    discriminator="foo_dataelement",
+                    validation_result=DataElementValidationResult(
+                        requirement_validation=RequirementValidationValue.IS_REQUIRED_AND_FILLED,
+                        hints="foo",
+                        format_validation_fulfilled=False,
+                        format_error_message="bar",
+                    ),
+                ),
+                {
+                    "discriminator": "foo_dataelement",
+                    "validation_result": {
+                        "requirement_validation": "IS_REQUIRED_AND_FILLED",
+                        "hints": "foo",
+                        "format_validation_fulfilled": False,
+                        "format_error_message": "bar",
+                        "possible_values": None,
+                    },
+                },
+            ),
         ],
     )
     def test_validation_result_in_context_serialization(


### PR DESCRIPTION
So that DataElementValidationResults are dumped completely
https://github.com/Hochfrequenz/wim-bee-backend/issues/455