### PR TITLE
(DRAFT) 🐛 Fix `ValidationResultInContextSchema().load`

### DIFF
--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -40,6 +40,10 @@ class ValidationResultSchema(ValidationResultAttributesSchema):
     A schema to (de-)serialize ValidationResult
     """
 
+    # todo: find out which type (inheriting from ValidationResult) we're dealing with
+    # build something similar to or better than
+    # https://github.com/Hochfrequenz/mig_ahb_utility_stack/blob/35bf3d0b0085a002ac3a30d9eb3886601287af9b/src/maus/models/edifact_components.py#L233
+
     @post_load
     def deserialize(self, data, **kwargs) -> ValidationResult:
         """

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -381,6 +381,9 @@ class TestJsonSerialization:
         assert json_string is not None
         actual_json_dict = json.loads(json_string)
         assert actual_json_dict == expected_json_dict
+        # the way back (json➡python object) is a bit tricky, because we don't know yet, which type we're dealing with
+        deserialized_validation_result_in_context = ValidationResultInContextSchema().load(actual_json_dict)
+        assert deserialized_validation_result_in_context == validation_result_in_context
 
     @pytest.mark.parametrize(
         "list_of_validation_result_in_context, expected_json_dict",


### PR DESCRIPTION
as of now, the problem is reproducable, see also the todo comment I added that refers to a similar "problem" in maus:
https://github.com/Hochfrequenz/mig_ahb_utility_stack/blob/35bf3d0b0085a002ac3a30d9eb3886601287af9b/src/maus/models/edifact_components.py#L233