### PR TITLE
🐛Fix: When using the cache, don't return the same instance, only a copy

### DIFF
--- a/src/ahbicht/expressions/ahb_expression_parser.py
+++ b/src/ahbicht/expressions/ahb_expression_parser.py
@@ -4,13 +4,14 @@ using the parsing library lark: https://lark-parser.readthedocs.io/en/latest/
 The goal is to separate the requirement indicator (i.e. Muss, Soll, Kann, X, O, U) from the condition expression
 and also several modal marks expressions if there are more than one.
 """
-from typing import Dict
+from functools import lru_cache
 
 from lark import Lark, Token, Tree
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF
 
 # pylint: disable=anomalous-backslash-in-string
 from ahbicht.expressions import parsing_logger
+from ahbicht.utility_functions import tree_copy
 
 GRAMMAR = """
 ahb_expression: modal_mark_expression+
@@ -29,12 +30,10 @@ CONDITION_EXPRESSION: /(?!\BU\B)[\[\]\(\)U∧O∨X⊻\d\sP\.UB]+/i
 # and CTRL+F for "Mus[2]" in the unittest that fails if you remove the lookahead.
 _parser = Lark(GRAMMAR, start="ahb_expression")
 
-_cache: Dict[str, Tree[Token]] = {}  #: holds the ahb expression as key and the parsed Tree as value
 
-
-def parse_ahb_expression_to_single_requirement_indicator_expressions(
-    ahb_expression: str, disable_cache: bool = False
-) -> Tree[Token]:
+@tree_copy
+@lru_cache(maxsize=65536)
+def parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression: str) -> Tree[Token]:
     """
     Parse a given expression as it appears in the AHB with the help of the here defined grammar to a lark tree.
     The goal is to separate the requirement indicator (i.e. Muss/M Soll/S Kann/K, X, O, U) from the condition expression
@@ -42,14 +41,10 @@ def parse_ahb_expression_to_single_requirement_indicator_expressions(
     Whitespaces are ignored.
 
     :param ahb_expression: e.g. 'Muss[45]U[52] Soll[1]'
-    :param disable_cache: set to true to disable caching
     :return parsed_tree:
     """
-    if (not disable_cache) and ahb_expression in _cache:
-        return _cache[ahb_expression]
     try:
         parsed_tree = _parser.parse(ahb_expression)
-        _cache.update({ahb_expression: parsed_tree})
         parsing_logger.debug("Successfully parsed '%s' as AHB expression", ahb_expression)
     except (UnexpectedEOF, UnexpectedCharacters, TypeError) as eof:
         raise SyntaxError(

--- a/src/ahbicht/expressions/condition_expression_parser.py
+++ b/src/ahbicht/expressions/condition_expression_parser.py
@@ -5,6 +5,7 @@ the parsing library lark: https://lark-parser.readthedocs.io/en/latest/
 The used terms are defined in the README_conditions.md.
 """
 # pylint:disable=cyclic-import
+from functools import lru_cache
 from typing import Dict, List, Union
 
 from lark import Lark, Token, Tree
@@ -13,6 +14,7 @@ from lark.exceptions import UnexpectedCharacters, UnexpectedEOF
 from ahbicht.condition_node_distinction import ConditionNodeType, derive_condition_node_type
 from ahbicht.content_evaluation.categorized_key_extract import CategorizedKeyExtract
 from ahbicht.expressions import parsing_logger
+from ahbicht.utility_functions import tree_copy
 
 GRAMMAR = r"""
 ?expression: expression "O"i expression -> or_composition
@@ -40,10 +42,10 @@ PACKAGE_KEY: INT "P" // a TERMINAL for all INTs followed by "P" (high priority)
 """
 _parser = Lark(GRAMMAR, start="expression")
 
-_cache: Dict[str, Tree[Token]] = {}  #: holds the condition expression as key and the parsed Tree as value
 
-
-def parse_condition_expression_to_tree(condition_expression: str, disable_cache: bool = True) -> Tree[Token]:
+@tree_copy
+@lru_cache(maxsize=65536)
+def parse_condition_expression_to_tree(condition_expression: str) -> Tree[Token]:
     """
     Parse a given condition expression with the help of the here defined grammar to a lark tree.
     The grammar starts with condition keys, e.g. [45] and combines them with
@@ -52,14 +54,10 @@ def parse_condition_expression_to_tree(condition_expression: str, disable_cache:
     Whitespaces are ignored.
 
     :param condition_expression: str, e.g. '[45]U[502]O[1][906]'
-    :param disable_cache: set to False to enable caching
     :return parsed_tree: Tree
     """
-    if (not disable_cache) and condition_expression in _cache:
-        return _cache[condition_expression]
     try:
         parsed_tree = _parser.parse(condition_expression)
-        _cache.update({condition_expression: parsed_tree})
         parsing_logger.debug("Successfully parsed '%s' as condition expression", condition_expression)
     except (UnexpectedEOF, UnexpectedCharacters, TypeError) as eof:
         raise SyntaxError(

--- a/src/ahbicht/expressions/expression_resolver.py
+++ b/src/ahbicht/expressions/expression_resolver.py
@@ -20,7 +20,7 @@ from ahbicht.mapping_results import Repeatability, parse_repeatability
 
 
 async def parse_expression_including_unresolved_subexpressions(
-    expression: str, resolve_packages: bool = False, replace_time_conditions: bool = True, disable_cache: bool = True
+    expression: str, resolve_packages: bool = False, replace_time_conditions: bool = True
 ) -> Tree[Token]:
     """
     Parses expressions and resolves its subexpressions,
@@ -30,9 +30,7 @@ async def parse_expression_including_unresolved_subexpressions(
     :param replace_time_conditions: if true the time conditions "UBx" are replaced with format constraints
     """
     try:
-        expression_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(
-            expression, disable_cache=disable_cache
-        )
+        expression_tree = parse_ahb_expression_to_single_requirement_indicator_expressions(expression)
         expression_tree = AhbExpressionResolverTransformer().transform(expression_tree)
     except SyntaxError as ahb_syntax_error:
         try:

--- a/src/ahbicht/validation/validation.py
+++ b/src/ahbicht/validation/validation.py
@@ -75,7 +75,7 @@ async def validate_segment_level(
     if isinstance(segment_level, Segment):
         return await validate_segment(segment=segment_level, soll_is_required=soll_is_required)
 
-    raise NotImplementedError("Unexpected type for segement_level")
+    raise NotImplementedError("Unexpected type for segment_level")
 
 
 async def validate_segment_group(

--- a/unittests/test_ahb_expression_parser.py
+++ b/unittests/test_ahb_expression_parser.py
@@ -4,10 +4,7 @@
 import pytest  # type:ignore[import]
 from lark import Token, Tree
 
-from ahbicht.expressions.ahb_expression_parser import (
-    _cache,
-    parse_ahb_expression_to_single_requirement_indicator_expressions,
-)
+from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
 
 
 class TestAhbExpressionParser:
@@ -355,10 +352,10 @@ class TestAhbExpressionParser:
         assert parsed_tree == expected_tree
         log_entries = caplog.records
         if len(log_entries) > 0:
-            assert caplog.records[0].message == f"Successfully parsed '{ahb_expression}' as AHB expression"
-        else:
-            # if the tree is not actually parsed but loaded from the cache we don't expect a logging message
-            assert ahb_expression in _cache
+            assert caplog.records[0].message in {
+                f"Successfully parsed '{ahb_expression}' as AHB expression",
+                f"The parsed tree for '{ahb_expression}' has been loaded from the cache",
+            }
 
     @pytest.mark.parametrize(
         "ahb_expression",

--- a/unittests/test_caching.py
+++ b/unittests/test_caching.py
@@ -1,13 +1,13 @@
 import asyncio
-import timeit
+from itertools import product
+from typing import List
 
 import pytest  # type:ignore[import]
 import pytest_asyncio  # type:ignore[import]
+from lark import Tree
 
-from ahbicht.expressions.ahb_expression_parser import _cache as ahb_expr_cache
 from ahbicht.expressions.ahb_expression_parser import _parser as ahb_expr_parser
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
-from ahbicht.expressions.condition_expression_parser import _cache as cond_expr_cache
 from ahbicht.expressions.condition_expression_parser import _parser as cond_expr_parser
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 
@@ -17,61 +17,25 @@ class TestCaching:
     Tests the caching capabilities of both ahb and condition expression parsers
     """
 
-    @pytest.fixture()
-    def clear_caches(self):
-        ahb_expr_cache.clear()
-        cond_expr_cache.clear()
-
-    # test expressions have to be unique per test case because the tests interfere (they share the same "global" cache)
-
-    @pytest.mark.parametrize(
-        "ahb_expression",
-        [
-            pytest.param("Muss [7] U [8]", id="simple expression"),
-            pytest.param(
-                "Muss [7] U [8] X ([112] O [2343] X [3] U [9]) O ([1] U [2] U ([12] O [13]) O [12 U [222])",
-                id="longer expression",
-            ),
-        ],
-    )
-    def test_ahb_expression_cache_performance(self, clear_caches, ahb_expression: str):
-        # be careful with performance tests. they naturally behave different on different systems
-        calls = 1000
-        time_with_cache = timeit.timeit(
-            lambda: parse_ahb_expression_to_single_requirement_indicator_expressions(
-                ahb_expression, disable_cache=False
-            ),
-            number=calls,
-        )
-
-        time_without_cache = timeit.timeit(
-            lambda: parse_ahb_expression_to_single_requirement_indicator_expressions(
-                ahb_expression, disable_cache=True
-            ),
-            number=calls,
-        )
-
-        avg_time_per_parsing_with_cache = time_with_cache / calls
-        avg_time_per_parsing_without_cache = time_without_cache / calls
-        assert avg_time_per_parsing_with_cache < avg_time_per_parsing_without_cache / 100
-        # a 100-fold performance improvement for 1000 calls of a simple expression seems fair
-        # still, the overall time spent in parsing is not large: the order of magnitude for parsing without cache is 1ms
-
-    def test_ahb_expression_cache_disabled(self, clear_caches, mocker):
-        ahb_expression = "Muss [1] U [2]"
-        parse_spy = mocker.spy(ahb_expr_parser, "parse")
-        for _ in range(100):
-            _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression, disable_cache=True)
-        assert parse_spy.call_count == 100
-
-    def test_ahb_expression_cache_sync(self, clear_caches, mocker):
+    def test_ahb_expression_cache_sync(self, mocker):
         ahb_expression = "Muss [3] U [4]"
         parse_spy = mocker.spy(ahb_expr_parser, "parse")
-        for _ in range(100):
-            _ = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
+        tree_instances: List[Tree] = []
+        number_of_calls = 100
+        for _ in range(number_of_calls):
+            tree_instance = parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_expression)
+            tree_instances.append(tree_instance)
         parse_spy.assert_called_once_with(ahb_expression)
+        # The following assertion is to make sure that each cached call actually returns a new instance of a lark tree.
+        # We do not want the same instance to be returned and eventually be modified over and over again.
+        number_of_distinct_instances = (
+            len(tree_instances)
+            * len(tree_instances)
+            / len([1 for x, y in product(tree_instances, tree_instances) if x is y])
+        )
+        assert number_of_distinct_instances == number_of_calls
 
-    async def test_ahb_expression_cache_async(self, clear_caches, mocker):
+    async def test_ahb_expression_cache_async(self, mocker):
 
         ahb_expression = "Muss [5] U [6]"
         parse_spy = mocker.spy(ahb_expr_parser, "parse")
@@ -83,20 +47,29 @@ class TestCaching:
         await asyncio.gather(*tasks)
         parse_spy.assert_called_once_with(ahb_expression)
 
-    def test_condition_expression_cache_sync(self, clear_caches, mocker):
+    def test_condition_expression_cache_sync(self, mocker):
         cond_expression = "[1] U [2]"
         parse_spy = mocker.spy(cond_expr_parser, "parse")
-        for _ in range(100):
-            _ = parse_condition_expression_to_tree(cond_expression, disable_cache=False)
+        tree_instances: List[Tree] = []
+        number_of_calls = 100
+        for _ in range(number_of_calls):
+            tree_instance = parse_condition_expression_to_tree(cond_expression)
+            tree_instances.append(tree_instance)
         parse_spy.assert_called_once_with(cond_expression)
+        number_of_distinct_instances = (
+            len(tree_instances)
+            * len(tree_instances)
+            / len([1 for x, y in product(tree_instances, tree_instances) if x is y])
+        )
+        assert number_of_distinct_instances == number_of_calls
 
-    async def test_condition_expression_cache_async(self, clear_caches, mocker):
+    async def test_condition_expression_cache_async(self, mocker):
         # test expression has to be different from the cond_expression in the sync test case because the tests interfere
         cond_expression = "[3] U [4]"
         parse_spy = mocker.spy(cond_expr_parser, "parse")
 
         async def parsing_task():
-            parse_condition_expression_to_tree(cond_expression, disable_cache=False)
+            parse_condition_expression_to_tree(cond_expression)
 
         tasks = [parsing_task() for _ in range(100)]
         await asyncio.gather(*tasks)


### PR DESCRIPTION
Das Problem ging folgendermaßen:

Wenn wir bisher einen Expression geparsed haben (egal ob Condition Expression oder AHB Expression), haben wir das Ergebnis des Parsers (den Tree) anschließend in einem Cache (Dictionary) zwischengespeichert. Die Motivation war, dass wir vermeiden, dass der vglw. zeitintensive Parser ein zweites Mal aufgerufen wird, wenn das Ergebnis schon bekannt ist. Gleiche Expressions führen immer (bis auf parserspezifische Ausnahmen) zu gleichen Bäumen. (Die Ausnahmen ist, dass z.B. "[1] O [2] O [3]" nicht stabil als "([1] O [2]) O [3]" oder als "[1] O ([2] O [3])" rauskommt, quasi flackernde Klammern)

Der große Fehler war, dass wir immer die gleiche Instanz des Trees ("den selben Tree) zurückgegeben haben, nicht nur den gleichen Tree.

Wenn also nachfolgender Code des einen Parsing-Vorgangs den Baum anschließend modifziert hat, dann hat das den Baum für alle anderen Wege die der Baum genutzt hat auch modifiziert. Jede Mussfeldprüfung modifiziert den Baum ...

Der Fehler bestand seit v0.3.2 (#191). Witzigerweise direkt [mit Ankündigung](https://github.com/Hochfrequenz/ahbicht/pull/191#discussion_r902379765) eingeführt.

@hf-fvesely hat die Auswirkungen des Bug in https://github.com/Hochfrequenz/ahbicht-functions/issues/62 beschrieben und er sollte seit #204 (v0.4.4) nicht mehr aufgetreten sein, es sei denn der aufrufende Code, der ahbicht importiert hat das caching ausdrücklich angeschaltet.

Der schnellste Quickfix wäre gewesen: Statt den Baum, den wir zurückgeben im Cache abzulegen, erzeugen wir eine Kopie des Baums (`tree.copy()`) und geben immer nur Kopien dieser Baumvorlage wieder raus, die der aufrufende Code dann modifizieren kann wie er will ohne dass es weitere Auswirkungen hat.

Dann hab ich gelernt, dass Python schon einen integrierten Caching-Mechanismus hat (hat auch @hf-krechan auch schonmal erwähnt): memoize oder [`lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache). Also habe ich anstatt das Rad nicht (wie fälschlicherweise in #191) neu zu erfinden, diesen Cache aus der std lib verwendet. Der hat aber das gleiche Problem, dass die selbe Instanz des Baums zurück gibt statt immer neue Kopien des gleichen Baums. Deswegen habe ich den `tree_copy`-Decorator eingeführt, der die Ergebnisse aus dem Cache erst in eine neue Tree-Instanz kopiert.
Um das in den Tests zu messen habe ich die so ausgebaut, dass mittels`treeA is treeB` zählen, wie viele der vom Cache zurückgebenen Bäume identisch sind (das wollen wir nicht) und wie viele "nur" gleich aber nicht identisch: Es sollten gleich viele _gleiche_ Bäume sein wie Aufrufe der cachenden Parsing-Funktion und ebensoviele unterschiedliche Instanzen.

Man kann das jetzt leicht validieren: Wenn man den tree-copy-decorator wegnimmt failen diese Tests.