### PR TITLE
minor (test only) renaming: "valid" != "well-formed"

### DIFF
--- a/src/ahbicht/expressions/ahb_expression_parser.py
+++ b/src/ahbicht/expressions/ahb_expression_parser.py
@@ -47,6 +47,7 @@ def parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_express
         parsed_tree = _parser.parse(ahb_expression)
         parsing_logger.debug("Successfully parsed '%s' as AHB expression", ahb_expression)
     except (UnexpectedEOF, UnexpectedCharacters, TypeError) as eof:
+        # the expression is not well-formed
         raise SyntaxError(
             """Please make sure that the ahb_expression starts with a requirement indicator \
 (i.e Muss/M, Soll/S, Kann/K, X, O, U) and the condition expressions consist of only \

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -238,7 +238,7 @@ class TestAHBExpressionEvaluation:
             ),
         ],
     )
-    async def test_invalid_ahb_expressions(
+    async def test_not_wellformed_ahb_expressions(
         self, expression: str, expected_error: type, expected_error_message: str, setup_and_teardown_injector
     ):
         """Tests that an error is raised when trying to pass invalid values."""


### PR DESCRIPTION
I'd like to introduce a little differentiation with a nomenclature very similar to XML/HTML.

- we call those expressions **"well-formed"** which obey the general syntax rules (not well-formed expressions raise an SyntaxError)
- we call those expressions **"valid"** (or at least _not_ invalid) that are both well-formed and can have a meaningful evaluation outcome

Motivation: ahbicht shall be used to flag well-formed expressions that are invalid though.

E.g.
> `Muss ([77] u[78]) u (([61]u [584]) o[583])"`

is well-formed (obeys the syntax rules, has balanced brackets and uses only allowed operators and tokens) but still the expression is invalid, because the part `([61]u [584]) o[583]` cannot be evaluated.
https://github.com/Hochfrequenz/edifact-templates/issues/133

This raises errors at evaluation runtime which I'd like to prevent and spot in advance.