### PR TITLE
checkout 3

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,7 +9,7 @@ jobs:
         python-version: ["3.10"]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3
       - name: Black Code Formatter
         uses: lgeiger/black-action@v1.0.1
         with:

--- a/.github/workflows/packaging_test.yml
+++ b/.github/workflows/packaging_test.yml
@@ -9,9 +9,9 @@ jobs:
         python-version: [3.9, "3.10"]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/pythonlint.yml
+++ b/.github/workflows/pythonlint.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest]
         linter-env: ["linting", "type_check"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies

--- a/.github/workflows/typescript_from_json_schemas.yml
+++ b/.github/workflows/typescript_from_json_schemas.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,9 +9,9 @@ jobs:
         python-version: [3.9, "3.10"]
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout