### PR TITLE
Replace `(str, Enum)` with `enum.StrEnum` from stdlib for Python 3.11

### DIFF
--- a/src/ahbicht/__init__.py
+++ b/src/ahbicht/__init__.py
@@ -1,18 +1,21 @@
 """
 AHBicht is a lark based parser and evaluation framework for conditions that occur in Anwendungshandbüchern (AHB).
 """
-from typing import Type
+from enum import Enum
 
-StrEnum: Type
+
+class StrEnum(str, Enum):
+    """
+    An enum class of which each member has a string representation.
+    This is a workaround for Python <v3.11 because enum.StrEnum was introduced in Python 3.11.
+    """
+
+
 try:
     from enum import StrEnum as std_lib_strenum
 
-    StrEnum = std_lib_strenum
+    StrEnum = std_lib_strenum  # type:ignore[misc, assignment]
 except ImportError:
-    # this import error occurs for python < 3.11
-    from enum import Enum
-
-    class SelfDefinedStrEnum(str, Enum):
-        pass
-
-    StrEnum = SelfDefinedStrEnum
+    # This import error occurs for python < 3.11
+    # We'll live with the fallback class defined above. The unit test for python 3.9-3.11 ensure that this works.
+    pass

--- a/src/ahbicht/__init__.py
+++ b/src/ahbicht/__init__.py
@@ -1,3 +1,18 @@
 """
 AHBicht is a lark based parser and evaluation framework for conditions that occur in Anwendungshandbüchern (AHB).
 """
+from typing import Type
+
+StrEnum: Type
+try:
+    from enum import StrEnum as std_lib_strenum
+
+    StrEnum = std_lib_strenum
+except ImportError:
+    # this import error occurs for python < 3.11
+    from enum import Enum
+
+    class SelfDefinedStrEnum(str, Enum):
+        pass
+
+    StrEnum = SelfDefinedStrEnum

--- a/src/ahbicht/condition_node_distinction.py
+++ b/src/ahbicht/condition_node_distinction.py
@@ -1,10 +1,16 @@
 """
 A module to allow easy distinction between different types of condition nodes (by mapping their integer key)
 """
-from enum import Enum
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
 
 
-class ConditionNodeType(str, Enum):
+class ConditionNodeType(StrEnum):
     """
     Possible types of condition nodes.
     The value is usually determined using the key of the respective condition node.

--- a/src/ahbicht/condition_node_distinction.py
+++ b/src/ahbicht/condition_node_distinction.py
@@ -1,13 +1,7 @@
 """
 A module to allow easy distinction between different types of condition nodes (by mapping their integer key)
 """
-try:
-    from enum import StrEnum
-except ImportError:
-    from enum import Enum
-
-    class StrEnum(str, Enum):
-        pass
+from ahbicht import StrEnum
 
 
 class ConditionNodeType(StrEnum):

--- a/src/ahbicht/expressions/enums.py
+++ b/src/ahbicht/expressions/enums.py
@@ -1,19 +1,13 @@
 """
 Enums used in AHB and condition expressions.
 """
-try:
-    from enum import StrEnum
-except ImportError:
-    from enum import Enum
-
-    class StrEnum(str, Enum):
-        pass
-
 
 from enum import unique
 from typing import Dict, Literal, Union
 
 from marshmallow import Schema, fields, post_dump, post_load, pre_load
+
+from ahbicht import StrEnum
 
 
 @unique

--- a/src/ahbicht/expressions/enums.py
+++ b/src/ahbicht/expressions/enums.py
@@ -1,14 +1,23 @@
 """
 Enums used in AHB and condition expressions.
 """
-from enum import Enum, unique
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+
+from enum import unique
 from typing import Dict, Literal, Union
 
 from marshmallow import Schema, fields, post_dump, post_load, pre_load
 
 
 @unique
-class ModalMark(str, Enum):
+class ModalMark(StrEnum):
     """
     A modal mark describes if information are obligatory or not. The German term is "Merkmal".
     The modal marks are defined by the EDI Energy group (see edi-energy.de → Dokumente → Allgemeine Festlegungen).
@@ -36,7 +45,7 @@ class ModalMark(str, Enum):
 
 
 @unique
-class PrefixOperator(str, Enum):
+class PrefixOperator(StrEnum):
     """
     Operator which does not function to combine conditions, but as requirement indicator.
     It stands alone or in front of a condition expression. Please find detailed descriptions of the operators and their
@@ -110,7 +119,7 @@ class RequirementIndicatorSchema(Schema):
         return data["value"].upper()
 
 
-class LogicalOperator(str, Enum):
+class LogicalOperator(StrEnum):
     """
     Logical operators connect two tokens.
     """

--- a/src/ahbicht/validation/validation_values.py
+++ b/src/ahbicht/validation/validation_values.py
@@ -1,9 +1,15 @@
 """This module contains the enums for the possible validation values."""
 
-from enum import Enum
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
 
 
-class RequirementValidationValue(str, Enum):
+class RequirementValidationValue(StrEnum):
     """
     Possible values to describe the state of the validation
     in the requirement_validation attribute of the ValidationResult.

--- a/src/ahbicht/validation/validation_values.py
+++ b/src/ahbicht/validation/validation_values.py
@@ -1,12 +1,5 @@
 """This module contains the enums for the possible validation values."""
-
-try:
-    from enum import StrEnum
-except ImportError:
-    from enum import Enum
-
-    class StrEnum(str, Enum):
-        pass
+from ahbicht import StrEnum
 
 
 class RequirementValidationValue(StrEnum):


### PR DESCRIPTION
but maintain backwards compatability