### PR TITLE
Use `skip_existing: True` in PyPI Publish Workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -54,3 +54,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
> ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         File already exists. See https://pypi.org/help/#file-name-reuse for    
         more information.