### PR TITLE
Remove unnecessary `type:ignore[...]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ asyncio_mode = "auto"
 markers = [
     "datafiles"
 ]
+
+[tool.mypy]
+# warn_unused_ignores = true # doesn't work,because either 'error: Cannot infer type argument 1 of "Tree"  [misc]' but this is also flagged as unused ignore

--- a/src/ahbicht/expressions/condition_expression_parser.py
+++ b/src/ahbicht/expressions/condition_expression_parser.py
@@ -93,19 +93,19 @@ def extract_categorized_keys_from_tree(
         condition_keys = tree_or_list
     elif isinstance(tree_or_list, Tree):
         condition_keys = [
-            x.value  # type:ignore[attr-defined]
+            x.value
             for x in tree_or_list.scan_values(
                 lambda token: token.type == "CONDITION_KEY"  # type:ignore[union-attr]
             )
         ]
         result.package_keys = [
-            x.value  # type:ignore[attr-defined]
+            x.value
             for x in tree_or_list.scan_values(
                 lambda token: token.type == "PACKAGE_KEY"  # type:ignore[union-attr]
             )
         ]
         result.time_condition_keys = [
-            x.value  # type:ignore[attr-defined]
+            x.value
             for x in tree_or_list.scan_values(
                 lambda token: token.type == "TIME_CONDITION_KEY"  # type:ignore[union-attr]
             )

--- a/src/ahbicht/expressions/expression_resolver.py
+++ b/src/ahbicht/expressions/expression_resolver.py
@@ -76,9 +76,9 @@ async def _replace_sub_coroutines_with_awaited_results(tree: Union[Tree, Awaitab
         result = await tree
     else:
         # if the tree type hint is correct this is always a tree if it's not awaitable
-        result = tree  # type:ignore[assignment]
+        result = tree
     # todo: check why lark type hints state the return value of scan_values is always Iterator[str]
-    sub_results = await asyncio.gather(*result.scan_values(asyncio.iscoroutine))  # type:ignore[call-overload]
+    sub_results = await asyncio.gather(*result.scan_values(asyncio.iscoroutine))
     for coro, sub_result in zip(result.scan_values(asyncio.iscoroutine), sub_results):
         for sub_tree in result.iter_subtrees():
             for child_index, child in enumerate(sub_tree.children):
@@ -140,7 +140,7 @@ class PackageExpansionTransformer(Transformer):
         if not resolved_package.has_been_resolved_successfully():
             raise NotImplementedError(f"The package '{package_key_token.value}' could not be resolved by {resolver}")
         # the package_expression is not None because that's the definition of "has been resolved successfully"
-        tree_result = parse_condition_expression_to_tree(resolved_package.package_expression)  # type:ignore[arg-type]
+        tree_result = parse_condition_expression_to_tree(resolved_package.package_expression)
         return tree_result
 
 

--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -102,7 +102,7 @@ async def format_constraint_evaluation(
     else:
         parsed_tree_fc: Tree = parse_condition_expression_to_tree(format_constraints_expression)
         all_evaluatable_format_constraint_keys: List[str] = [
-            t.value for t in parsed_tree_fc.scan_values(lambda v: isinstance(v, Token))  # type:ignore[attr-defined]
+            t.value for t in parsed_tree_fc.scan_values(lambda v: isinstance(v, Token))
         ]
         input_values: Dict[
             str, EvaluatedFormatConstraint

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -256,9 +256,7 @@ async def requirement_constraint_evaluation(
         parsed_tree_rc = condition_expression
 
     # get all condition keys from tree
-    all_condition_keys: List[str] = [
-        t.value for t in parsed_tree_rc.scan_values(lambda v: isinstance(v, Token))  # type: ignore[attr-defined]
-    ]
+    all_condition_keys: List[str] = [t.value for t in parsed_tree_rc.scan_values(lambda v: isinstance(v, Token))]
     condition_node_builder = ConditionNodeBuilder(all_condition_keys)
     input_nodes = await condition_node_builder.requirement_content_evaluation_for_all_condition_keys()
 

--- a/src/ahbicht/mapping_results.py
+++ b/src/ahbicht/mapping_results.py
@@ -7,7 +7,7 @@ from typing import Match, Optional
 import attrs
 from efoli import EdifactFormat
 from marshmallow import Schema, fields, post_load
-from marshmallow_enum import EnumField  # type:ignore[import]
+from marshmallow_enum import EnumField  # type:ignore[import-untyped]
 
 
 # pylint:disable=too-few-public-methods

--- a/src/ahbicht/validation/validation.py
+++ b/src/ahbicht/validation/validation.py
@@ -278,7 +278,7 @@ async def validate_data_element_freetext(
                 hints=invalid_expr_error.error_message,
                 data_element_data_type=DataElementDataType.TEXT,
             ),
-            discriminator=data_element.discriminator,  # type:ignore[arg-type]
+            discriminator=data_element.discriminator,
         )
 
     # requirement constraints
@@ -311,7 +311,7 @@ async def validate_data_element_freetext(
         str(result),
     )
     return ValidationResultInContext(
-        discriminator=data_element.discriminator,  # type:ignore[arg-type]
+        discriminator=data_element.discriminator,
         validation_result=result,
     )
 
@@ -401,7 +401,7 @@ async def validate_data_element_valuepool(
         str(result),
     )
     return ValidationResultInContext(
-        discriminator=data_element.discriminator,  # type:ignore[arg-type]
+        discriminator=data_element.discriminator,
         validation_result=result,
     )
 

--- a/src/ahbicht/validation/validation_results.py
+++ b/src/ahbicht/validation/validation_results.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 import attrs
 import maus.models.edifact_components
 from marshmallow import Schema, fields, post_load
-from marshmallow_enum import EnumField  # type:ignore[import]
+from marshmallow_enum import EnumField  # type:ignore[import-untyped]
 
 from ahbicht.validation.validation_values import RequirementValidationValue
 

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -3,8 +3,8 @@ why conftest.py?
 https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session
 """
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation import ContentEvaluationResult, EvaluatableData, TokenLogicProvider
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResultSchema

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -4,8 +4,8 @@ from typing import List
 from unittest.mock import AsyncMock
 
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider
@@ -254,7 +254,7 @@ class TestAHBExpressionEvaluation:
         """Tests that a meaningful error raised when the user forgot to setup bind_to_provider"""
 
         parsed_tree = parse_ahb_expression_to_single_requirement_indicator_expressions("Muss [1] U [2]")
-        with pytest.raises(AttributeError) as excinfo:  # type: ignore[var-annotated]
+        with pytest.raises(AttributeError) as excinfo:
             await evaluate_ahb_expression_tree(parsed_tree)
         assert "Are you sure you called .bind_to_provider" in str(excinfo.value)
 

--- a/unittests/test_ahb_expression_parser.py
+++ b/unittests/test_ahb_expression_parser.py
@@ -1,6 +1,6 @@
 """ Tests for the parsing of the ahb_expressions as they appear in the AHBs. """
 
-import pytest  # type:ignore[import]
+import pytest
 from lark import Token, Tree
 
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
@@ -17,7 +17,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "requirement_indicator",
                             [
                                 Token("MODAL_MARK", "Muss"),
@@ -31,7 +31,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "requirement_indicator",
                             [
                                 Token("PREFIX_OPERATOR", "X"),
@@ -45,7 +45,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Muss"),
@@ -60,7 +60,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Soll"),
@@ -90,7 +90,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Muss"),
@@ -105,7 +105,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Kann"),
@@ -120,7 +120,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Kann"),
@@ -135,7 +135,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("PREFIX_OPERATOR", "X"),
@@ -150,7 +150,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("PREFIX_OPERATOR", "O"),
@@ -165,7 +165,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("PREFIX_OPERATOR", "O"),
@@ -180,7 +180,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Kann"),
@@ -195,7 +195,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Kann"),
@@ -210,7 +210,7 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "kann"),
@@ -225,21 +225,21 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Muss"),
                                 Token("CONDITION_EXPRESSION", "[3]U[4]"),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Soll"),
                                 Token("CONDITION_EXPRESSION", "[5]    "),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Kann"),
@@ -254,21 +254,21 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "M"),
                                 Token("CONDITION_EXPRESSION", "[3]U[4]"),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "S"),
                                 Token("CONDITION_EXPRESSION", "[5]    "),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "K"),
@@ -283,21 +283,21 @@ class TestAhbExpressionParser:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "m"),
                                 Token("CONDITION_EXPRESSION", "[3]u[4]"),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "s"),
                                 Token("CONDITION_EXPRESSION", "[5]    "),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "k"),

--- a/unittests/test_caching.py
+++ b/unittests/test_caching.py
@@ -2,8 +2,8 @@ import asyncio
 from itertools import product
 from typing import List
 
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 from lark import Tree
 
 from ahbicht.expressions.ahb_expression_parser import _parser as ahb_expr_parser

--- a/unittests/test_categorized_key_extraction.py
+++ b/unittests/test_categorized_key_extraction.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import List
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation.categorized_key_extract import CategorizedKeyExtract, CategorizedKeyExtractSchema
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult, ContentEvaluationResultSchema

--- a/unittests/test_cer_based_fc_evaluator.py
+++ b/unittests/test_cer_based_fc_evaluator.py
@@ -2,8 +2,8 @@
 from typing import Optional
 
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider

--- a/unittests/test_cer_based_hints_provider.py
+++ b/unittests/test_cer_based_hints_provider.py
@@ -2,8 +2,8 @@
 from typing import Optional
 
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider

--- a/unittests/test_cer_based_package_resolver.py
+++ b/unittests/test_cer_based_package_resolver.py
@@ -1,8 +1,8 @@
 """ Tests the PackageResolver, that assumes a ContentEvaluationResult to be present in the evaluatable data"""
 
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider

--- a/unittests/test_cer_based_rc_evaluator.py
+++ b/unittests/test_cer_based_rc_evaluator.py
@@ -1,7 +1,7 @@
 """ Tests the RC evaluator, that assumes a ContentEvaluationResult to be present in the evaluatable data"""
 from unittest import mock
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.rc_evaluators import ContentEvaluationResultBasedRcEvaluator, RcEvaluator

--- a/unittests/test_condition_node_builder.py
+++ b/unittests/test_condition_node_builder.py
@@ -2,8 +2,8 @@
 from pathlib import Path
 
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 
 from ahbicht.condition_node_builder import ConditionNodeBuilder
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider, EvaluationContext

--- a/unittests/test_condition_nodes.py
+++ b/unittests/test_condition_nodes.py
@@ -1,6 +1,6 @@
 """ Tests for creating different condition nodes that are used in the parsed tree. """
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.expressions.condition_nodes import (
     ConditionFulfilledValue,

--- a/unittests/test_condition_parser.py
+++ b/unittests/test_condition_parser.py
@@ -3,7 +3,7 @@ import asyncio
 import datetime
 import random
 
-import pytest  # type:ignore[import]
+import pytest
 from lark import Token, Tree
 
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
@@ -83,10 +83,10 @@ class TestConditionParser:
             pytest.param(
                 # and/or combination, and before or
                 "[1]U[2]    O[53]",
-                Tree(
+                Tree(  # type:ignore[misc]
                     "or_composition",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "and_composition",
                             [
                                 Tree("condition", [Token("CONDITION_KEY", "1")]),
@@ -100,11 +100,11 @@ class TestConditionParser:
             pytest.param(
                 # and/or combination, and before or, different order
                 "[53]O[1]U[2]",
-                Tree(
+                Tree(  # type:ignore[misc]
                     "or_composition",
                     [
                         Tree("condition", [Token("CONDITION_KEY", "53")]),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "and_composition",
                             [
                                 Tree("condition", [Token("CONDITION_KEY", "1")]),
@@ -380,7 +380,7 @@ class TestConditionParser:
                         Tree(  # type:ignore[misc]
                             "or_composition",
                             [
-                                Tree(
+                                Tree(  # type:ignore[misc]
                                     "and_composition",
                                     [
                                         Tree("condition", [Token("CONDITION_KEY", "53")]),

--- a/unittests/test_dict_based_fc_evaluator.py
+++ b/unittests/test_dict_based_fc_evaluator.py
@@ -2,7 +2,7 @@
 from typing import Optional
 from unittest import mock
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation import fc_evaluators
 from ahbicht.content_evaluation.fc_evaluators import DictBasedFcEvaluator, FcEvaluator

--- a/unittests/test_dict_based_rc_evaluator.py
+++ b/unittests/test_dict_based_rc_evaluator.py
@@ -1,7 +1,7 @@
 """ Tests the dictionary based RC evaluator"""
 from unittest import mock
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator
 from ahbicht.expressions.condition_nodes import ConditionFulfilledValue

--- a/unittests/test_evaluator_factory.py
+++ b/unittests/test_evaluator_factory.py
@@ -3,8 +3,8 @@ import uuid
 from typing import Optional
 
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult
 from ahbicht.content_evaluation.evaluator_factory import create_and_inject_hardcoded_evaluators

--- a/unittests/test_evaluator_provider.py
+++ b/unittests/test_evaluator_provider.py
@@ -1,7 +1,6 @@
 from typing import List
 
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
 from efoli import EdifactFormat, EdifactFormatVersion
 
 from ahbicht.content_evaluation.evaluators import Evaluator

--- a/unittests/test_expression_builder.py
+++ b/unittests/test_expression_builder.py
@@ -1,7 +1,7 @@
 """
 Tests the expression builder module.
 """
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.expressions.condition_nodes import Hint, UnevaluatedFormatConstraint
 from ahbicht.expressions.expression_builder import FormatConstraintExpressionBuilder, HintExpressionBuilder

--- a/unittests/test_expression_resolver.py
+++ b/unittests/test_expression_resolver.py
@@ -1,4 +1,4 @@
-import pytest  # type:ignore[import]
+import pytest
 from lark import Token, Tree
 
 from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
@@ -17,7 +17,7 @@ class TestExpressionResolver:
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Muss"),
-                                Tree(
+                                Tree(  # type:ignore[misc]
                                     "and_composition",
                                     [
                                         Tree("condition", [Token("CONDITION_KEY", "3")]),
@@ -26,7 +26,7 @@ class TestExpressionResolver:
                                 ),
                             ],
                         ),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("MODAL_MARK", "Soll"),
@@ -41,11 +41,11 @@ class TestExpressionResolver:
                 Tree(  # type:ignore[misc]
                     "ahb_expression",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "single_requirement_indicator_expression",
                             [
                                 Token("PREFIX_OPERATOR", "X"),
-                                Tree(
+                                Tree(  # type:ignore[misc]
                                     "or_composition",
                                     [
                                         Tree("condition", [Token("CONDITION_KEY", "504")]),
@@ -59,11 +59,11 @@ class TestExpressionResolver:
             ),
             pytest.param(
                 "[905]([504]U[6])",
-                Tree(
+                Tree(  # type:ignore[misc]
                     "then_also_composition",
                     [
                         Tree("condition", [Token("CONDITION_KEY", "905")]),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "and_composition",
                             [
                                 Tree("condition", [Token("CONDITION_KEY", "504")]),

--- a/unittests/test_format_constraint_expression_evaluation.py
+++ b/unittests/test_format_constraint_expression_evaluation.py
@@ -3,8 +3,8 @@ from logging import LogRecord
 from typing import List, Optional
 
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 
 from ahbicht.content_evaluation import fc_evaluators
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider

--- a/unittests/test_german_strom_and_gas_tag.py
+++ b/unittests/test_german_strom_and_gas_tag.py
@@ -3,7 +3,7 @@ Tests the evaluation of the start/end of a German Strom- or Gastag.
 """
 from datetime import datetime, timedelta, timezone
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation.german_strom_and_gas_tag import (
     berlin,

--- a/unittests/test_hints_provider.py
+++ b/unittests/test_hints_provider.py
@@ -6,7 +6,7 @@ import datetime
 from logging import LogRecord
 from typing import List
 
-import pytest  # type:ignore[import]
+import pytest
 from efoli import EdifactFormat, EdifactFormatVersion
 
 from ahbicht.expressions.hints_provider import HintsProvider, JsonFileHintsProvider

--- a/unittests/test_integration_mwe.py
+++ b/unittests/test_integration_mwe.py
@@ -4,8 +4,8 @@ from logging import LogRecord
 from typing import List
 
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 from maus.models.anwendungshandbuch import AhbMetaInformation, DeepAnwendungshandbuch
 from maus.models.edifact_components import (
     DataElementFreeText,

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from typing import List, TypeVar
 
-import pytest  # type:ignore[import]
+import pytest
 from efoli import EdifactFormat
 from marshmallow import Schema, ValidationError
 from maus.models.edifact_components import DataElementDataType

--- a/unittests/test_mixed_sync_async_rc_fc_evaluation.py
+++ b/unittests/test_mixed_sync_async_rc_fc_evaluation.py
@@ -3,7 +3,7 @@ Tests that the code can handle RC/FC evaluators that have both async and sync me
 """
 
 import inject
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, EvaluatableDataProvider, EvaluationContext
 from ahbicht.content_evaluation.fc_evaluators import FcEvaluator

--- a/unittests/test_package_resolver.py
+++ b/unittests/test_package_resolver.py
@@ -5,8 +5,8 @@ from logging import LogRecord
 from typing import List, Mapping, Optional
 
 import inject
-import pytest  # type:ignore[import]
-from _pytest.fixtures import SubRequest  # type:ignore[import]
+import pytest
+from _pytest.fixtures import SubRequest
 from efoli import EdifactFormat, EdifactFormatVersion
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider

--- a/unittests/test_requirement_constraint_evaluation.py
+++ b/unittests/test_requirement_constraint_evaluation.py
@@ -1,8 +1,8 @@
 """ Test for the requirement constraint evaluation of the condition expressions. """
 
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider
 from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider, TokenLogicProvider

--- a/unittests/test_requirement_constraint_expression_evaluation.py
+++ b/unittests/test_requirement_constraint_expression_evaluation.py
@@ -1,7 +1,7 @@
 """ Test for the evaluation of the conditions tests (Mussfeldprüfung) """
 from typing import Dict, Optional
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.expressions import InvalidExpressionError
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree

--- a/unittests/test_time_condition_resolver.py
+++ b/unittests/test_time_condition_resolver.py
@@ -2,7 +2,7 @@
 Test for the expansion of packages.
 """
 
-import pytest  # type:ignore[import]
+import pytest
 from lark import Token, Tree
 
 from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
@@ -77,17 +77,17 @@ class TestTimeConditionReplacement:
                 Tree(  # type:ignore[misc]
                     "and_composition",
                     [
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "xor_composition",
                             [
-                                Tree(
+                                Tree(  # type:ignore[misc]
                                     "then_also_composition",
                                     [
                                         Tree(Token("RULE", "condition"), [Token("CONDITION_KEY", "932")]),
                                         Tree(Token("RULE", "condition"), [Token("CONDITION_KEY", "492")]),
                                     ],
                                 ),
-                                Tree(
+                                Tree(  # type:ignore[misc]
                                     "then_also_composition",
                                     [
                                         Tree(Token("RULE", "condition"), [Token("CONDITION_KEY", "934")]),

--- a/unittests/test_tree_schemas.py
+++ b/unittests/test_tree_schemas.py
@@ -4,7 +4,7 @@
 Tests that the parsed trees are JSON serializable
 """
 
-import pytest  # type:ignore[import]
+import pytest
 from lark import Token, Tree
 
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
@@ -26,11 +26,11 @@ class TestTreeSchemas:
         "tree, expected_json_dict",
         [
             pytest.param(
-                Tree(
+                Tree(  # type:ignore[misc]
                     "or_composition",
                     [
                         Tree("condition_key", [Token("INT", "53")]),
-                        Tree(
+                        Tree(  # type:ignore[misc]
                             "and_composition",
                             [Tree("condition_key", [Token("INT", "1")]), Tree("condition_key", [Token("INT", "2")])],
                         ),

--- a/unittests/test_utility_functions.py
+++ b/unittests/test_utility_functions.py
@@ -3,7 +3,7 @@ Tests the utility functions.
 """
 from typing import Awaitable, List, TypeVar, Union
 
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.mapping_results import Repeatability, parse_repeatability
 from ahbicht.utility_functions import gather_if_necessary

--- a/unittests/test_validation.py
+++ b/unittests/test_validation.py
@@ -3,7 +3,7 @@ from itertools import product
 from typing import List
 
 import inject
-import pytest  # type:ignore[import]
+import pytest
 from maus.models.anwendungshandbuch import AhbMetaInformation, DeepAnwendungshandbuch
 from maus.models.edifact_components import (
     DataElementDataType,

--- a/unittests/test_validation_results.py
+++ b/unittests/test_validation_results.py
@@ -1,4 +1,4 @@
-import pytest  # type:ignore[import]
+import pytest
 from maus.models.edifact_components import DataElementDataType
 
 from ahbicht.validation.validation_results import (
@@ -247,5 +247,5 @@ class TestValidationResults:
     async def test_lovric_remove_absender_and_empfaenger_path_results(
         self, lovric_actual: ListOfValidationResultInContext, lovric_expected: ListOfValidationResultInContext
     ):
-        lovric_actual.remove_absender_and_empfaenger_path_results()  # type:ignore[attr-defined]
+        lovric_actual.remove_absender_and_empfaenger_path_results()
         assert lovric_actual == lovric_expected

--- a/unittests/test_validity_check.py
+++ b/unittests/test_validity_check.py
@@ -2,7 +2,7 @@ from contextvars import ContextVar
 from typing import Optional
 
 import inject
-import pytest  # type:ignore[import]
+import pytest
 
 from ahbicht.content_evaluation import is_valid_expression
 from ahbicht.content_evaluation.content_evaluation_result import ContentEvaluationResult, ContentEvaluationResultSchema

--- a/unittests/test_warning_when_using_inject_attr.py
+++ b/unittests/test_warning_when_using_inject_attr.py
@@ -1,6 +1,6 @@
 import inject
-import pytest  # type:ignore[import]
-import pytest_asyncio  # type:ignore[import]
+import pytest
+import pytest_asyncio
 
 from unittests.defaults import EmptyDefaultRcEvaluator
 


### PR DESCRIPTION
found using mypy --strict, but we cannot switch to `--strict` yet because there are >100 other errors to be resolved first. I wanted to split it. Here's part 1.