### PR TITLE
Move `ahbicht.mapping_results` to `ahbicht.models.mapping_results` and `parse_repeatability()` from `ahbicht.mapping_results` to `ahbicht.utility_functions`

### DIFF
--- a/json_schemas/generate_json_schemas.py
+++ b/json_schemas/generate_json_schemas.py
@@ -11,7 +11,6 @@ from marshmallow import Schema, fields
 from marshmallow_jsonschema import JSONSchema  # type:ignore[import]
 
 from ahbicht.json_serialization.tree_schema import TokenSchema  # , TreeSchema
-from ahbicht.mapping_results import ConditionKeyConditionTextMappingSchema, PackageKeyConditionExpressionMappingSchema
 from ahbicht.models.categorized_key_extract import CategorizedKeyExtractSchema
 from ahbicht.models.condition_nodes import EvaluatedFormatConstraintSchema
 from ahbicht.models.content_evaluation_result import ContentEvaluationResultSchema
@@ -19,6 +18,10 @@ from ahbicht.models.evaluation_results import (
     AhbExpressionEvaluationResultSchema,
     FormatConstraintEvaluationResultSchema,
     RequirementConstraintEvaluationResultSchema,
+)
+from ahbicht.models.mapping_results import (
+    ConditionKeyConditionTextMappingSchema,
+    PackageKeyConditionExpressionMappingSchema,
 )
 
 schema_types: List[Type[Schema]] = [

--- a/src/ahbicht/expressions/expression_resolver.py
+++ b/src/ahbicht/expressions/expression_resolver.py
@@ -17,7 +17,8 @@ from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider
 from ahbicht.expressions.ahb_expression_parser import parse_ahb_expression_to_single_requirement_indicator_expressions
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.package_expansion import PackageResolver
-from ahbicht.mapping_results import Repeatability, parse_repeatability
+from ahbicht.models.mapping_results import Repeatability
+from ahbicht.utility_functions import parse_repeatability
 
 
 async def parse_expression_including_unresolved_subexpressions(

--- a/src/ahbicht/expressions/package_expansion.py
+++ b/src/ahbicht/expressions/package_expansion.py
@@ -13,8 +13,11 @@ import inject
 from efoli import EdifactFormat, EdifactFormatVersion
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, EvaluatableDataProvider
-from ahbicht.mapping_results import PackageKeyConditionExpressionMapping, PackageKeyConditionExpressionMappingSchema
 from ahbicht.models.content_evaluation_result import ContentEvaluationResult, ContentEvaluationResultSchema
+from ahbicht.models.mapping_results import (
+    PackageKeyConditionExpressionMapping,
+    PackageKeyConditionExpressionMappingSchema,
+)
 
 
 # pylint:disable=too-few-public-methods

--- a/src/ahbicht/models/mapping_results.py
+++ b/src/ahbicht/models/mapping_results.py
@@ -2,8 +2,7 @@
 This module contains classes that are returned by mappers, meaning they contain a mapping.
 """
 
-import re
-from typing import Match, Optional
+from typing import Optional
 
 import attrs
 from efoli import EdifactFormat
@@ -130,18 +129,3 @@ class Repeatability:
         returns true if the package used together with this repeatability is optional
         """
         return self.min_occurrences == 0
-
-
-_repeatability_pattern = re.compile(r"^(?P<min>\d+)\.{2}(?P<max>\d+)$")  #: a pattern to match "n..m" repeatabilities
-
-
-def parse_repeatability(repeatability_string: str) -> Repeatability:
-    """
-    parses the given string as repeatability; e.g. `17..23` is parsed as min=17, max=23
-    """
-    match: Optional[Match[str]] = _repeatability_pattern.match(repeatability_string)
-    if match is None:
-        raise ValueError(f"The given string '{repeatability_string}' could not be parsed as repeatability")
-    min_repeatability = int(match["min"])
-    max_repeatability = int(match["max"])
-    return Repeatability(min_occurrences=min_repeatability, max_occurrences=max_repeatability)

--- a/unittests/test_cer_based_package_resolver.py
+++ b/unittests/test_cer_based_package_resolver.py
@@ -4,8 +4,8 @@ import inject
 import pytest
 
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider
-from ahbicht.mapping_results import PackageKeyConditionExpressionMapping
 from ahbicht.models.content_evaluation_result import ContentEvaluationResult
+from ahbicht.models.mapping_results import PackageKeyConditionExpressionMapping
 from unittests.defaults import default_test_format, default_test_version
 
 

--- a/unittests/test_json_serialization.py
+++ b/unittests/test_json_serialization.py
@@ -11,12 +11,6 @@ from efoli import EdifactFormat
 from marshmallow import Schema, ValidationError
 from maus.models.edifact_components import DataElementDataType
 
-from ahbicht.mapping_results import (
-    ConditionKeyConditionTextMapping,
-    ConditionKeyConditionTextMappingSchema,
-    PackageKeyConditionExpressionMapping,
-    PackageKeyConditionExpressionMappingSchema,
-)
 from ahbicht.models.categorized_key_extract import CategorizedKeyExtract, CategorizedKeyExtractSchema
 from ahbicht.models.condition_nodes import (
     ConditionFulfilledValue,
@@ -30,6 +24,12 @@ from ahbicht.models.evaluation_results import (
     AhbExpressionEvaluationResultSchema,
     FormatConstraintEvaluationResult,
     RequirementConstraintEvaluationResult,
+)
+from ahbicht.models.mapping_results import (
+    ConditionKeyConditionTextMapping,
+    ConditionKeyConditionTextMappingSchema,
+    PackageKeyConditionExpressionMapping,
+    PackageKeyConditionExpressionMappingSchema,
 )
 from ahbicht.models.validation_results import (
     DataElementValidationResult,

--- a/unittests/test_package_resolver.py
+++ b/unittests/test_package_resolver.py
@@ -15,7 +15,8 @@ from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicP
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.expression_resolver import expand_packages
 from ahbicht.expressions.package_expansion import JsonFilePackageResolver, PackageResolver
-from ahbicht.mapping_results import PackageKeyConditionExpressionMapping, Repeatability, parse_repeatability
+from ahbicht.models.mapping_results import PackageKeyConditionExpressionMapping, Repeatability
+from ahbicht.utility_functions import parse_repeatability
 from unittests.defaults import DefaultPackageResolver, return_empty_dummy_evaluatable_data
 
 

--- a/unittests/test_utility_functions.py
+++ b/unittests/test_utility_functions.py
@@ -6,8 +6,8 @@ from typing import Awaitable, List, TypeVar, Union
 
 import pytest
 
-from ahbicht.mapping_results import Repeatability, parse_repeatability
-from ahbicht.utility_functions import gather_if_necessary
+from ahbicht.models.mapping_results import Repeatability
+from ahbicht.utility_functions import gather_if_necessary, parse_repeatability
 
 T = TypeVar("T")
 


### PR DESCRIPTION
and `parse_repeatability` from `ahbicht.mapping_results` to `ahbicht.utility_functions`
