### PR TITLE
fix: gracefully handle `V` and `v` instead of `∨`

### DIFF
--- a/src/ahbicht/expressions/ahb_expression_parser.py
+++ b/src/ahbicht/expressions/ahb_expression_parser.py
@@ -31,6 +31,12 @@ CONDITION_EXPRESSION: /(?!\BU\B)[\[\]\(\)U∧O∨X⊻\d\sP\.UB]+/i
 # and CTRL+F for "Mus[2]" in the unittest that fails if you remove the lookahead.
 _parser = Lark(GRAMMAR, start="ahb_expression")
 
+_replacements: dict[str, str] = {
+    "\u00a0": " ",  # no-break space,
+    "V": "∨",  # Vogel-V != logical OR
+    "v": "∨",
+}
+
 
 @tree_copy
 @lru_cache(maxsize=1024)
@@ -46,7 +52,8 @@ def parse_ahb_expression_to_single_requirement_indicator_expressions(ahb_express
     """
     try:
         if ahb_expression is not None:
-            ahb_expression = ahb_expression.replace("\u00a0", " ")  # for sanity: remove no-break space
+            for key, value in _replacements.items():
+                ahb_expression = ahb_expression.replace(key, value)
         parsed_tree = _parser.parse(ahb_expression)
         parsing_logger.debug("Successfully parsed '%s' as AHB expression", ahb_expression)
     except (UnexpectedEOF, UnexpectedCharacters, TypeError) as eof:

--- a/unittests/test_validity_check.py
+++ b/unittests/test_validity_check.py
@@ -67,6 +67,9 @@ class TestValidityCheck:
             ),  # unbalanced brackets
             pytest.param("Muss [15] ∧ [2050]", True),  # contains a 'Geschütztes' Leerzeichen
             pytest.param("Muss [15]🙄∧ [2050]", False),
+            pytest.param(
+                "X ([950] [509] ∧ ([64] V [70])) V ([960] [522] ∧ [71] ∧ [53])", True
+            ),  # nur echt mit 'V' statt LOR
         ],
     )
     async def test_is_valid_expression(self, ahb_expression: str, expected_result: bool, inject_cer_evaluators):


### PR DESCRIPTION
denn sie wissen nicht, was sie tun
