### PR TITLE
feat: add AhbContext dataclass for explicit dependency passing (w/o using it anywhere yet)

### DIFF
--- a/src/ahbicht/content_evaluation/ahb_context.py
+++ b/src/ahbicht/content_evaluation/ahb_context.py
@@ -1,0 +1,117 @@
+"""
+AhbContext bundles all collaborators needed for AHB expression evaluation.
+
+Instead of relying on a global dependency injection container, consumers create an AhbContext
+and pass it explicitly to parsing and evaluation functions. This makes the data flow visible
+and eliminates global mutable state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from efoli import EdifactFormat, EdifactFormatVersion
+
+from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
+from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
+from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
+from ahbicht.expressions.hints_provider import HintsProvider
+from ahbicht.expressions.package_expansion import PackageResolver
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider
+    from ahbicht.models.content_evaluation_result import ContentEvaluationResult
+
+
+@dataclass
+class AhbContext:
+    """
+    Holds all the collaborators needed for AHB expression evaluation and package resolution.
+
+    There are two typical ways to create an AhbContext:
+
+    1. From a ContentEvaluationResult (pre-computed results, e.g. in a REST API):
+       ``AhbContext.from_content_evaluation_result(cer, edifact_format, edifact_format_version)``
+
+    2. With custom evaluator instances (on-demand evaluation, e.g. in a message validator):
+       ``AhbContext(rc_evaluator=..., fc_evaluator=..., ...)``
+    """
+
+    rc_evaluator: RcEvaluator
+    fc_evaluator: FcEvaluator
+    hints_provider: HintsProvider
+    package_resolver: PackageResolver
+    evaluatable_data: EvaluatableData[Any]
+
+    @staticmethod
+    def from_content_evaluation_result(
+        content_evaluation_result: ContentEvaluationResult,
+        edifact_format: EdifactFormat,
+        edifact_format_version: EdifactFormatVersion,
+        evaluatable_data: Optional[EvaluatableData[Any]] = None,
+    ) -> AhbContext:
+        """
+        Creates an AhbContext from a ContentEvaluationResult.
+
+        This is the simplest way to use ahbicht when all evaluation results are already known.
+        Internally, this creates dict-based evaluators that just look up results from the CER.
+
+        :param content_evaluation_result: the pre-computed evaluation results
+        :param edifact_format: the EDIFACT format (e.g. UTILMD)
+        :param edifact_format_version: the EDIFACT format version (e.g. FV2210)
+        :param evaluatable_data: optional EvaluatableData; if None, one is created from the CER
+        """
+        from ahbicht.content_evaluation.evaluator_factory import (  # pylint:disable=import-outside-toplevel
+            create_hardcoded_evaluators,
+        )
+
+        rc_evaluator, fc_evaluator, hints_provider, package_resolver = create_hardcoded_evaluators(
+            content_evaluation_result,
+            edifact_format=edifact_format,
+            edifact_format_version=edifact_format_version,
+        )
+
+        if evaluatable_data is None:
+            evaluatable_data = EvaluatableData(
+                body=content_evaluation_result.model_dump(mode="json"),
+                edifact_format=edifact_format,
+                edifact_format_version=edifact_format_version,
+            )
+
+        return AhbContext(
+            rc_evaluator=rc_evaluator,
+            fc_evaluator=fc_evaluator,
+            hints_provider=hints_provider,
+            package_resolver=package_resolver,
+            evaluatable_data=evaluatable_data,
+        )
+
+    @staticmethod
+    def from_token_logic_provider(
+        token_logic_provider: TokenLogicProvider,
+        evaluatable_data: EvaluatableData[Any],
+    ) -> AhbContext:
+        """
+        Creates an AhbContext from a TokenLogicProvider and EvaluatableData.
+
+        This is a bridge for existing code that already has a configured TokenLogicProvider.
+
+        :param token_logic_provider: a configured TokenLogicProvider instance
+        :param evaluatable_data: the data to evaluate against
+        """
+        return AhbContext(
+            rc_evaluator=token_logic_provider.get_rc_evaluator(
+                evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+            ),
+            fc_evaluator=token_logic_provider.get_fc_evaluator(
+                evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+            ),
+            hints_provider=token_logic_provider.get_hints_provider(
+                evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+            ),
+            package_resolver=token_logic_provider.get_package_resolver(
+                evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+            ),
+            evaluatable_data=evaluatable_data,
+        )

--- a/unittests/test_ahb_context.py
+++ b/unittests/test_ahb_context.py
@@ -1,0 +1,125 @@
+"""
+Tests for the AhbContext dataclass and its factory methods.
+"""
+
+import pytest
+from efoli import EdifactFormat, EdifactFormatVersion
+
+from ahbicht.content_evaluation.ahb_context import AhbContext
+from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
+from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator, RcEvaluator
+from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
+from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider
+from ahbicht.expressions.hints_provider import HintsProvider
+from ahbicht.expressions.package_expansion import PackageResolver
+from ahbicht.models.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint
+from ahbicht.models.content_evaluation_result import ContentEvaluationResult
+from unittests.defaults import (
+    default_test_format,
+    default_test_version,
+    empty_default_fc_evaluator,
+    empty_default_hints_provider,
+    empty_default_package_resolver,
+    empty_default_rc_evaluator,
+    empty_default_test_data,
+)
+
+
+class TestAhbContextDirectConstruction:
+    """Tests for creating AhbContext with explicit evaluator instances."""
+
+    def test_creates_context_with_all_fields(self):
+        ctx = AhbContext(
+            rc_evaluator=empty_default_rc_evaluator,
+            fc_evaluator=empty_default_fc_evaluator,
+            hints_provider=empty_default_hints_provider,
+            package_resolver=empty_default_package_resolver,
+            evaluatable_data=empty_default_test_data,
+        )
+        assert isinstance(ctx.rc_evaluator, RcEvaluator)
+        assert isinstance(ctx.fc_evaluator, FcEvaluator)
+        assert isinstance(ctx.hints_provider, HintsProvider)
+        assert isinstance(ctx.package_resolver, PackageResolver)
+        assert ctx.evaluatable_data is empty_default_test_data
+
+
+class TestAhbContextFromContentEvaluationResult:
+    """Tests for the from_content_evaluation_result factory method."""
+
+    def test_creates_context_from_cer(self):
+        cer = ContentEvaluationResult(
+            requirement_constraints={"2": ConditionFulfilledValue.FULFILLED},
+            format_constraints={"901": EvaluatedFormatConstraint(format_constraint_fulfilled=True)},
+            hints={"555": "some hint"},
+        )
+        ctx = AhbContext.from_content_evaluation_result(
+            cer,
+            edifact_format=default_test_format,
+            edifact_format_version=default_test_version,
+        )
+        assert isinstance(ctx.rc_evaluator, RcEvaluator)
+        assert isinstance(ctx.fc_evaluator, FcEvaluator)
+        assert isinstance(ctx.hints_provider, HintsProvider)
+        assert isinstance(ctx.package_resolver, PackageResolver)
+        assert ctx.evaluatable_data.edifact_format == default_test_format
+        assert ctx.evaluatable_data.edifact_format_version == default_test_version
+
+    def test_uses_provided_evaluatable_data_if_given(self):
+        cer = ContentEvaluationResult(
+            requirement_constraints={},
+            format_constraints={},
+            hints={},
+        )
+        custom_data = EvaluatableData(
+            body={"custom": True},
+            edifact_format=EdifactFormat.UTILMD,
+            edifact_format_version=EdifactFormatVersion.FV2210,
+        )
+        ctx = AhbContext.from_content_evaluation_result(
+            cer,
+            edifact_format=default_test_format,
+            edifact_format_version=default_test_version,
+            evaluatable_data=custom_data,
+        )
+        assert ctx.evaluatable_data is custom_data
+
+    @pytest.mark.asyncio
+    async def test_rc_evaluator_returns_correct_values(self):
+        cer = ContentEvaluationResult(
+            requirement_constraints={
+                "2": ConditionFulfilledValue.FULFILLED,
+                "3": ConditionFulfilledValue.UNFULFILLED,
+            },
+            format_constraints={},
+            hints={},
+        )
+        ctx = AhbContext.from_content_evaluation_result(
+            cer,
+            edifact_format=default_test_format,
+            edifact_format_version=default_test_version,
+        )
+        result = await ctx.rc_evaluator.evaluate_single_condition("2", ctx.evaluatable_data)
+        assert result == ConditionFulfilledValue.FULFILLED
+
+        result = await ctx.rc_evaluator.evaluate_single_condition("3", ctx.evaluatable_data)
+        assert result == ConditionFulfilledValue.UNFULFILLED
+
+
+class TestAhbContextFromTokenLogicProvider:
+    """Tests for the from_token_logic_provider bridge factory."""
+
+    def test_creates_context_from_tlp(self):
+        tlp = SingletonTokenLogicProvider(
+            [
+                empty_default_rc_evaluator,
+                empty_default_fc_evaluator,
+                empty_default_hints_provider,
+                empty_default_package_resolver,
+            ]
+        )
+        ctx = AhbContext.from_token_logic_provider(tlp, empty_default_test_data)
+        assert ctx.rc_evaluator is empty_default_rc_evaluator
+        assert ctx.fc_evaluator is empty_default_fc_evaluator
+        assert ctx.hints_provider is empty_default_hints_provider
+        assert ctx.package_resolver is empty_default_package_resolver
+        assert ctx.evaluatable_data is empty_default_test_data

--- a/unittests/test_ahb_context.py
+++ b/unittests/test_ahb_context.py
@@ -7,8 +7,8 @@ from efoli import EdifactFormat, EdifactFormatVersion
 
 from ahbicht.content_evaluation.ahb_context import AhbContext
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
-from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator, RcEvaluator
 from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
+from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator, RcEvaluator
 from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider
 from ahbicht.expressions.hints_provider import HintsProvider
 from ahbicht.expressions.package_expansion import PackageResolver


### PR DESCRIPTION
## Summary

- Introduces `AhbContext` dataclass in `src/ahbicht/content_evaluation/ahb_context.py` — bundles `rc_evaluator`, `fc_evaluator`, `hints_provider`, `package_resolver`, and `evaluatable_data` into a single explicit context object
- Two factory methods: `from_content_evaluation_result` (for pre-computed results like ahbicht-functions) and `from_token_logic_provider` (bridge for existing inject-based code)
- This is **PR 1 of a migration series** to replace `python-inject` global DI with explicit parameter passing

## Migration context

This is the first step in a multi-PR effort to:
1. Separate parsing from evaluation
2. Replace the global `python-inject` DI container with explicit `AhbContext` passing
3. Make the library easier to set up and reason about

**No action required by consumers yet** — this is a pure addition. Subsequent PRs will thread `AhbContext` through `evaluate_ahb_expression_tree` and `parse_expression_including_unresolved_subexpressions` as an optional parameter (defaulting to `None` = old inject behavior).

## For future consumers: how to use AhbContext

```python
from ahbicht.content_evaluation.ahb_context import AhbContext

# Option 1: From pre-computed results (simplest)
ctx = AhbContext.from_content_evaluation_result(cer, EdifactFormat.UTILMD, EdifactFormatVersion.FV2210)

# Option 2: With custom evaluators
ctx = AhbContext(rc_evaluator=..., fc_evaluator=..., hints_provider=..., package_resolver=..., evaluatable_data=...)

# Option 3: Bridge from existing TokenLogicProvider
ctx = AhbContext.from_token_logic_provider(tlp, evaluatable_data)
```

## Test plan

- [x] 5 new tests covering direct construction, CER factory, custom evaluatable_data, RC evaluator correctness, TLP bridge
- [x] All 529 existing tests still pass
- [x] pylint 10.00/10
- [x] mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)