### PR TITLE
feat: thread AhbContext through ConditionNodeBuilder (dual-path)

### DIFF
--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -3,8 +3,10 @@ Module for taking all the condition keys of a condition expression and building 
 If necessary it evaluates the needed attributes.
 """
 
+from __future__ import annotations
+
 import sys
-from typing import Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import inject
 
@@ -12,6 +14,9 @@ from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, Eval
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider
 from ahbicht.expressions.condition_expression_parser import extract_categorized_keys_from_tree
 from ahbicht.models.condition_nodes import Hint, RequirementConstraint, UnevaluatedFormatConstraint
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 
 # TRCTransformerArgument is a union of nodes that are already evaluated from a Requirement Constraint (RC) perspective.
 # The Format Constraints (FC) might still be unevaluated. That's why the return type used in the
@@ -29,8 +34,16 @@ class ConditionNodeBuilder:
     It distinguishes between requirement constraint evaluation and format constraint evaluation.
     """
 
-    def __init__(self, condition_keys: list[str]) -> None:
-        self.token_logic_provider: TokenLogicProvider = inject.instance(TokenLogicProvider)  # type: ignore[assignment]
+    def __init__(self, condition_keys: list[str], ahb_context: Optional[AhbContext] = None) -> None:
+        self._ahb_context = ahb_context
+        if ahb_context is not None:
+            # New path: use the explicit context — no global inject needed
+            pass
+        else:
+            # Legacy path: fall back to global inject container (used by wanna.bee and older code)
+            self.token_logic_provider: TokenLogicProvider = inject.instance(  # type: ignore[assignment]
+                TokenLogicProvider
+            )
         self.condition_keys = condition_keys
         (
             self.requirement_constraints_condition_keys,
@@ -54,6 +67,9 @@ class ConditionNodeBuilder:
     # search for binder.bind_to_provider(EvaluatableDataProvider, your_function_that_returns_evaluatable_data_goes_here)
     async def _build_hint_nodes(self, evaluatable_data: EvaluatableData) -> dict[str, Hint]:
         """Builds Hint nodes from their condition keys by getting all hint texts from the HintsProvider."""
+        if self._ahb_context is not None:
+            return await self._ahb_context.hints_provider.get_hints(self.hints_condition_keys)
+        # Legacy inject path
         hints_provider = self.token_logic_provider.get_hints_provider(
             evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
         )
@@ -75,9 +91,13 @@ class ConditionNodeBuilder:
         Build requirement constraint nodes by evaluating the constraints
         with the help of the respective Evaluator.
         """
-        rc_evaluator = self.token_logic_provider.get_rc_evaluator(
-            evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
-        )
+        if self._ahb_context is not None:
+            rc_evaluator = self._ahb_context.rc_evaluator
+            evaluatable_data = self._ahb_context.evaluatable_data
+        else:
+            rc_evaluator = self.token_logic_provider.get_rc_evaluator(
+                evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+            )
         evaluated_conditions_fulfilled_attribute = await rc_evaluator.evaluate_conditions(
             condition_keys=self.requirement_constraints_condition_keys, evaluatable_data=evaluatable_data
         )
@@ -91,26 +111,35 @@ class ConditionNodeBuilder:
 
     async def requirement_content_evaluation_for_all_condition_keys(self) -> dict[str, TRCTransformerArgument]:
         """Gets input nodes for all condition keys."""
-        try:
-            requirement_constraint_nodes = (
-                await self._build_requirement_constraint_nodes()  # pylint:disable=no-value-for-parameter
+        if self._ahb_context is not None:
+            # New path: pass evaluatable_data explicitly to bypass @inject.params
+            evaluatable_data = self._ahb_context.evaluatable_data
+            requirement_constraint_nodes = await self._build_requirement_constraint_nodes(
+                evaluatable_data=evaluatable_data
             )
-            # the missing value should be injected automatically
-        except AttributeError as attribute_error:
-            # the 'name' attribute of the Attribute error has been added in Python3.10
-            # https://docs.python.org/3/library/exceptions.html#AttributeError
-            if (sys.version_info.minor < 10 or attribute_error.name == "edifact_format") and attribute_error.args[
-                0
-            ].startswith("'EvaluatableDataProvider' object has no attribute"):
-                # This means the injection was not set up correctly.
-                # Instead of the EvaluatableDataProvider being called (which would return EvaluatableData),
-                # an instance of the EvaluatableDataProvider itself was instantiated.
-                # Most likely you're missing binder.bind_to_provider(EvaluatableDataProvider, callable_goes_here)
-                attribute_error.args = (
-                    attribute_error.args[0] + ". Are you sure you called .bind_to_provider before?",
+            hint_nodes = await self._build_hint_nodes(evaluatable_data=evaluatable_data)
+        else:
+            # Legacy inject path: let @inject.params fill in evaluatable_data
+            try:
+                requirement_constraint_nodes = (
+                    await self._build_requirement_constraint_nodes()  # pylint:disable=no-value-for-parameter
                 )
-            raise  # re-raise with an eventually slightly modified error message
-        hint_nodes = await self._build_hint_nodes()  # pylint:disable=no-value-for-parameter
+                # the missing value should be injected automatically
+            except AttributeError as attribute_error:
+                # the 'name' attribute of the Attribute error has been added in Python3.10
+                # https://docs.python.org/3/library/exceptions.html#AttributeError
+                if (sys.version_info.minor < 10 or attribute_error.name == "edifact_format") and attribute_error.args[
+                    0
+                ].startswith("'EvaluatableDataProvider' object has no attribute"):
+                    # This means the injection was not set up correctly.
+                    # Instead of the EvaluatableDataProvider being called (which would return EvaluatableData),
+                    # an instance of the EvaluatableDataProvider itself was instantiated.
+                    # Most likely you're missing binder.bind_to_provider(EvaluatableDataProvider, callable_goes_here)
+                    attribute_error.args = (
+                        attribute_error.args[0] + ". Are you sure you called .bind_to_provider before?",
+                    )
+                raise  # re-raise with an eventually slightly modified error message
+            hint_nodes = await self._build_hint_nodes()  # pylint:disable=no-value-for-parameter
         unevaluated_format_constraint_nodes = self._build_unevaluated_format_constraint_nodes()
         input_nodes: dict[str, TRCTransformerArgument] = {
             **requirement_constraint_nodes,

--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -37,7 +37,8 @@ class ConditionNodeBuilder:
     def __init__(self, condition_keys: list[str], ahb_context: Optional[AhbContext] = None) -> None:
         self._ahb_context = ahb_context
         if ahb_context is not None:
-            # New path: use the explicit context — no global inject needed
+            # New path: all collaborators come from ahb_context.
+            # self.token_logic_provider is intentionally not set on this path.
             pass
         else:
             # Legacy path: fall back to global inject container (used by wanna.bee and older code)

--- a/unittests/test_condition_node_builder.py
+++ b/unittests/test_condition_node_builder.py
@@ -7,17 +7,25 @@ import pytest
 import pytest_asyncio
 
 from ahbicht.condition_node_builder import ConditionNodeBuilder
+from ahbicht.content_evaluation.ahb_context import AhbContext
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableDataProvider, EvaluationContext
-from ahbicht.content_evaluation.rc_evaluators import RcEvaluator
+from ahbicht.content_evaluation.rc_evaluators import DictBasedRcEvaluator, RcEvaluator
 from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider, TokenLogicProvider
-from ahbicht.expressions.hints_provider import JsonFileHintsProvider
+from ahbicht.expressions.hints_provider import DictBasedHintsProvider, JsonFileHintsProvider
 from ahbicht.models.condition_nodes import (
     ConditionFulfilledValue,
     Hint,
     RequirementConstraint,
     UnevaluatedFormatConstraint,
 )
-from unittests.defaults import default_test_format, default_test_version, return_empty_dummy_evaluatable_data
+from unittests.defaults import (
+    default_test_format,
+    default_test_version,
+    empty_default_fc_evaluator,
+    empty_default_package_resolver,
+    empty_default_test_data,
+    return_empty_dummy_evaluatable_data,
+)
 
 
 class DummyRcEvaluator(RcEvaluator):
@@ -190,3 +198,79 @@ class TestConditionNodeBuilder:
             "1..2": RequirementConstraint(condition_key="1..2", conditions_fulfilled=expected_conditions_fulfilled_1_2),
         }
         assert evaluated_requirement_constraints == expected_requirement_constraints
+
+
+class TestConditionNodeBuilderWithAhbContext:
+    """Tests that ConditionNodeBuilder works with an explicit AhbContext (no inject setup)."""
+
+    @staticmethod
+    def _make_context(
+        rc_results: dict[str, ConditionFulfilledValue],
+        hints: dict[str, str],
+    ) -> AhbContext:
+        rc_evaluator = DictBasedRcEvaluator(rc_results)
+        rc_evaluator.edifact_format = default_test_format
+        rc_evaluator.edifact_format_version = default_test_version
+        hints_provider = DictBasedHintsProvider(hints)
+        hints_provider.edifact_format = default_test_format
+        hints_provider.edifact_format_version = default_test_version
+        return AhbContext(
+            rc_evaluator=rc_evaluator,
+            fc_evaluator=empty_default_fc_evaluator,
+            hints_provider=hints_provider,
+            package_resolver=empty_default_package_resolver,
+            evaluatable_data=empty_default_test_data,
+        )
+
+    def test_init_with_ahb_context_does_not_call_inject(self):
+        """AhbContext path must not touch inject at all."""
+        ctx = self._make_context(rc_results={}, hints={})
+        # This would fail with inject.InjectorException if inject were called
+        builder = ConditionNodeBuilder(["501", "12", "903"], ahb_context=ctx)
+        assert builder.requirement_constraints_condition_keys == ["12"]
+        assert builder.hints_condition_keys == ["501"]
+        assert builder.format_constraints_condition_keys == ["903"]
+
+    async def test_build_hint_nodes_with_ahb_context(self):
+        ctx = self._make_context(
+            rc_results={},
+            hints={
+                "583": "[583] Hinweis: Verwendung der ID der Marktlokation",
+                "584": "[584] Hinweis: Verwendung der ID der Messlokation",
+            },
+        )
+        builder = ConditionNodeBuilder(["584", "583"], ahb_context=ctx)
+        # Pass evaluatable_data explicitly to bypass @inject.params decorator
+        hint_nodes = await builder._build_hint_nodes(evaluatable_data=ctx.evaluatable_data)
+        assert "583" in hint_nodes
+        assert "584" in hint_nodes
+        assert hint_nodes["583"].hint == "[583] Hinweis: Verwendung der ID der Marktlokation"
+
+    async def test_build_rc_nodes_with_ahb_context(self):
+        ctx = self._make_context(
+            rc_results={
+                "11": ConditionFulfilledValue.FULFILLED,
+                "78": ConditionFulfilledValue.UNFULFILLED,
+            },
+            hints={},
+        )
+        builder = ConditionNodeBuilder(["11", "78"], ahb_context=ctx)
+        # Pass evaluatable_data explicitly to bypass @inject.params decorator
+        rc_nodes = await builder._build_requirement_constraint_nodes(evaluatable_data=ctx.evaluatable_data)
+        assert rc_nodes["11"].conditions_fulfilled == ConditionFulfilledValue.FULFILLED
+        assert rc_nodes["78"].conditions_fulfilled == ConditionFulfilledValue.UNFULFILLED
+
+    async def test_full_evaluation_with_ahb_context(self):
+        ctx = self._make_context(
+            rc_results={
+                "78": ConditionFulfilledValue.FULFILLED,
+                "11": ConditionFulfilledValue.UNFULFILLED,
+            },
+            hints={"583": "[583] Hinweis: Verwendung der ID der Marktlokation"},
+        )
+        builder = ConditionNodeBuilder(["78", "907", "11", "583"], ahb_context=ctx)
+        result = await builder.requirement_content_evaluation_for_all_condition_keys()
+        assert result["78"].conditions_fulfilled == ConditionFulfilledValue.FULFILLED
+        assert result["11"].conditions_fulfilled == ConditionFulfilledValue.UNFULFILLED
+        assert isinstance(result["583"], Hint)
+        assert isinstance(result["907"], UnevaluatedFormatConstraint)


### PR DESCRIPTION
## Summary

- `ConditionNodeBuilder.__init__` now accepts `ahb_context: Optional[AhbContext] = None`
- When provided, evaluators and evaluatable_data are taken directly from the context — no inject calls
- When `None` (default), falls back to the existing inject-based behavior — **no breaking change**
- `requirement_content_evaluation_for_all_condition_keys()` passes `evaluatable_data` explicitly to bypass `@inject.params` decorator when context is set

## Migration context

PR 2 of the inject removal series. Builds on #743.

**No action required by consumers yet** — the parameter defaults to `None`, preserving existing behavior. The next PRs will thread `ahb_context` up through `requirement_constraint_evaluation()` and `evaluate_ahb_expression_tree()`.

### Key learning: `@inject.params` decorator fires before method body

The `@inject.params(evaluatable_data=EvaluatableDataProvider)` decorator intercepts the call and tries to inject missing parameters *before* the method body runs. So checking `self._ahb_context` inside the method is too late. The solution: when `ahb_context` is set, pass `evaluatable_data` as an explicit keyword argument, which prevents the decorator from activating for that parameter.

## Test plan

- [x] 4 new tests in `TestConditionNodeBuilderWithAhbContext` — init, hints, RC nodes, full evaluation — all without any inject setup
- [x] All 9 existing tests still pass unchanged (backward compat)
- [x] 533 total tests pass
- [x] pylint 10/10, mypy clean, isort clean, black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)