### PR TITLE
feat: thread AhbContext through requirement_constraint_evaluation

### DIFF
--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -6,13 +6,18 @@ of the condition expression tree are handled.
 The used terms are defined in the README_conditions.md.
 """
 
-from typing import Literal, Mapping, Optional, Type, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Mapping, Optional, Type, Union
 
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
 
 from ahbicht.condition_node_builder import ConditionNodeBuilder, TRCTransformerArgument
 from ahbicht.expressions import InvalidExpressionError
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 from ahbicht.expressions.base_transformer import BaseTransformer
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.expression_builder import FormatConstraintExpressionBuilder, HintExpressionBuilder
@@ -242,11 +247,13 @@ of the type RequirementConstraint, Hint or FormatConstraint.""")
 
 async def requirement_constraint_evaluation(
     condition_expression: Union[str, Tree],
+    ahb_context: Optional[AhbContext] = None,
 ) -> RequirementConstraintEvaluationResult:
     """
     Evaluation of the condition expression in regard to the requirement conditions (rc).
     The condition expression can either be a string that still needs to be parsed as condition expression or a tree
     that has already been parsed.
+    :param ahb_context: optional AhbContext; if provided, bypasses the global inject container
     """
     if isinstance(condition_expression, str):
         parsed_tree_rc: Tree = parse_condition_expression_to_tree(condition_expression)
@@ -255,7 +262,7 @@ async def requirement_constraint_evaluation(
 
     # get all condition keys from tree
     all_condition_keys: list[str] = [t.value for t in parsed_tree_rc.scan_values(lambda v: isinstance(v, Token))]
-    condition_node_builder = ConditionNodeBuilder(all_condition_keys)
+    condition_node_builder = ConditionNodeBuilder(all_condition_keys, ahb_context=ahb_context)
     input_nodes = await condition_node_builder.requirement_content_evaluation_for_all_condition_keys()
 
     resulting_condition_node: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree_rc, input_nodes)

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -15,9 +15,6 @@ from lark.exceptions import VisitError
 
 from ahbicht.condition_node_builder import ConditionNodeBuilder, TRCTransformerArgument
 from ahbicht.expressions import InvalidExpressionError
-
-if TYPE_CHECKING:
-    from ahbicht.content_evaluation.ahb_context import AhbContext
 from ahbicht.expressions.base_transformer import BaseTransformer
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.expression_builder import FormatConstraintExpressionBuilder, HintExpressionBuilder
@@ -31,6 +28,9 @@ from ahbicht.models.condition_nodes import (
     UnevaluatedFormatConstraint,
 )
 from ahbicht.models.evaluation_results import RequirementConstraintEvaluationResult
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 
 
 @v_args(inline=True)  # Children are provided as *args instead of a list argument


### PR DESCRIPTION
## Summary

- `requirement_constraint_evaluation()` now accepts `ahb_context: Optional[AhbContext] = None`
- Passes it to `ConditionNodeBuilder(all_condition_keys, ahb_context=ahb_context)`
- One-line functional change + parameter addition — pure threading

## Migration context

PR 3 of the inject removal series. Builds on #744.

**No action required by consumers.** Default is `None` = existing inject behavior.

## Test plan

- [x] All 533 existing tests pass unchanged
- [x] pylint, mypy, isort, black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)