### PR TITLE
feat: thread AhbContext through format_constraint_evaluation

### DIFF
--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -6,20 +6,24 @@ of the format constraint expression tree are handled.
 The used terms are defined in the README_conditions.md.
 """
 
-from typing import Mapping, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping, Optional
 
 import inject
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, EvaluatableDataProvider
-from ahbicht.content_evaluation.fc_evaluators import FcEvaluator
 from ahbicht.content_evaluation.token_logic_provider import TokenLogicProvider
 from ahbicht.expressions.base_transformer import BaseTransformer
 from ahbicht.expressions.condition_expression_parser import parse_condition_expression_to_tree
 from ahbicht.expressions.expression_builder import FormatErrorMessageExpressionBuilder
 from ahbicht.models.condition_nodes import EvaluatedFormatConstraint
 from ahbicht.models.evaluation_results import FormatConstraintEvaluationResult
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 
 
 @v_args(inline=True)  # Children are provided as *args instead of a list argument
@@ -91,6 +95,7 @@ def evaluate_format_constraint_tree(
 
 async def format_constraint_evaluation(
     format_constraints_expression: Optional[str],
+    ahb_context: Optional[AhbContext] = None,
 ) -> FormatConstraintEvaluationResult:
     """
     Evaluation of the format constraint expression.
@@ -104,11 +109,18 @@ async def format_constraint_evaluation(
         all_evaluatable_format_constraint_keys: list[str] = [
             t.value for t in parsed_tree_fc.scan_values(lambda v: isinstance(v, Token))
         ]
-        input_values: dict[str, EvaluatedFormatConstraint] = (
-            await _build_evaluated_format_constraint_nodes(  # pylint:disable=no-value-for-parameter
+        if ahb_context is not None:
+            # New path: pass evaluatable_data explicitly to bypass @inject.params decorator
+            input_values: dict[str, EvaluatedFormatConstraint] = await _build_evaluated_format_constraint_nodes(
+                all_evaluatable_format_constraint_keys,
+                ahb_context=ahb_context,
+                evaluatable_data=ahb_context.evaluatable_data,
+            )
+        else:
+            # Legacy inject path: let @inject.params fill in evaluatable_data
+            input_values = await _build_evaluated_format_constraint_nodes(  # pylint:disable=no-value-for-parameter
                 all_evaluatable_format_constraint_keys
             )
-        )
         resulting_evaluated_format_constraint_node: EvaluatedFormatConstraint = evaluate_format_constraint_tree(
             parsed_tree_fc, input_values
         )
@@ -125,12 +137,17 @@ async def format_constraint_evaluation(
 async def _build_evaluated_format_constraint_nodes(
     evaluatable_format_constraint_keys: list[str],
     evaluatable_data: EvaluatableData,
+    ahb_context: Optional[AhbContext] = None,
 ) -> dict[str, EvaluatedFormatConstraint]:
     """Build evaluated format constraint nodes."""
 
-    token_logic_provider: TokenLogicProvider = inject.instance(TokenLogicProvider)  # type: ignore[assignment]
-    evaluator: FcEvaluator = token_logic_provider.get_fc_evaluator(
-        evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
-    )
+    if ahb_context is not None:
+        evaluator = ahb_context.fc_evaluator
+    else:
+        # Legacy inject path
+        token_logic_provider: TokenLogicProvider = inject.instance(TokenLogicProvider)  # type: ignore[assignment]
+        evaluator = token_logic_provider.get_fc_evaluator(
+            evaluatable_data.edifact_format, evaluatable_data.edifact_format_version
+        )
     evaluated_format_constraints = await evaluator.evaluate_format_constraints(evaluatable_format_constraint_keys)
     return evaluated_format_constraints


### PR DESCRIPTION
## Summary
- PR 4 of the inject removal migration series
- Adds an optional `ahb_context: AhbContext` parameter to `format_constraint_evaluation()` and `_build_evaluated_format_constraint_nodes()`
- When `ahb_context` is provided, uses `ahb_context.fc_evaluator` and `ahb_context.evaluatable_data` directly, bypassing both `@inject.params` and `inject.instance(TokenLogicProvider)`
- When `ahb_context` is `None`, falls back to the existing inject-based path (full backward compatibility)
- Passes `evaluatable_data` explicitly as a keyword argument to bypass the `@inject.params` decorator (same pattern as PR 2 / #744)

## Test plan
- [x] All 533 existing tests pass
- [x] pylint clean (10/10)
- [x] isort + black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)