### PR TITLE
feat: thread AhbContext through evaluate_ahb_expression_tree (milestone)

### DIFF
--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -80,14 +80,14 @@ class AhbExpressionTransformer(Transformer):
         """
         See :meth:`single_requirement_indicator_expression_async`
         """
-        rc_kwargs: dict = {}
+        context_kwargs: dict = {}
         if self._ahb_context is not None:
-            rc_kwargs["ahb_context"] = self._ahb_context
+            context_kwargs["ahb_context"] = self._ahb_context
         requirement_constraint_evaluation_result: RequirementConstraintEvaluationResult = (
-            await requirement_constraint_evaluation(condition_expression, **rc_kwargs)
+            await requirement_constraint_evaluation(condition_expression, **context_kwargs)
         )
         format_constraint_evaluation_result: FormatConstraintEvaluationResult = await format_constraint_evaluation(
-            requirement_constraint_evaluation_result.format_constraints_expression, **rc_kwargs
+            requirement_constraint_evaluation_result.format_constraints_expression, **context_kwargs
         )
 
         result_of_ahb_expression_evaluation: AhbExpressionEvaluationResult = AhbExpressionEvaluationResult(

--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -5,7 +5,9 @@ The AhbExpressionTransformer defines the rules how the different parts of the pa
 The used terms are defined in the README.md.
 """
 
-from typing import Awaitable, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Awaitable, Optional, Union
 
 from lark import Token, Transformer, Tree, v_args
 from lark.exceptions import VisitError
@@ -19,6 +21,9 @@ from ahbicht.models.evaluation_results import (
     RequirementConstraintEvaluationResult,
 )
 from ahbicht.utility_functions import gather_if_necessary
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 
 _str_to_modal_mark_mapping: dict[str, ModalMark] = {
     "MUSS": ModalMark.MUSS,
@@ -40,11 +45,12 @@ class AhbExpressionTransformer(Transformer):
     their respective condition expressions already evaluated to booleans.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, ahb_context: Optional[AhbContext] = None) -> None:
         """
         The input are the evaluated format constraint conditions in the form of ConditionNodes.
         """
         super().__init__()
+        self._ahb_context = ahb_context
 
     def CONDITION_EXPRESSION(self, condition_expression: Token) -> str:
         """Returns the condition expression."""
@@ -74,11 +80,14 @@ class AhbExpressionTransformer(Transformer):
         """
         See :meth:`single_requirement_indicator_expression_async`
         """
+        rc_kwargs: dict = {}
+        if self._ahb_context is not None:
+            rc_kwargs["ahb_context"] = self._ahb_context
         requirement_constraint_evaluation_result: RequirementConstraintEvaluationResult = (
-            await requirement_constraint_evaluation(condition_expression)
+            await requirement_constraint_evaluation(condition_expression, **rc_kwargs)
         )
         format_constraint_evaluation_result: FormatConstraintEvaluationResult = await format_constraint_evaluation(
-            requirement_constraint_evaluation_result.format_constraints_expression
+            requirement_constraint_evaluation_result.format_constraints_expression, **rc_kwargs
         )
 
         result_of_ahb_expression_evaluation: AhbExpressionEvaluationResult = AhbExpressionEvaluationResult(
@@ -148,16 +157,18 @@ class AhbExpressionTransformer(Transformer):
 
 async def evaluate_ahb_expression_tree(
     parsed_tree: Tree,
+    ahb_context: Optional[AhbContext] = None,
 ) -> AhbExpressionEvaluationResult:
     """
     Evaluates the tree built from the ahb expressions with the help of the AhbExpressionTransformer.
 
     :param parsed_tree: Tree
+    :param ahb_context: optional AhbContext; if provided, bypasses the global inject container
     :return: the result of the overall condition check (including requirement constraints, format constraints,
         several modal marks)
     """
     try:
-        result = AhbExpressionTransformer().transform(parsed_tree)
+        result = AhbExpressionTransformer(ahb_context=ahb_context).transform(parsed_tree)
     except VisitError as visit_err:
         raise visit_err.orig_exc
 

--- a/unittests/test_ahb_expression_evaluation.py
+++ b/unittests/test_ahb_expression_evaluation.py
@@ -489,3 +489,98 @@ class TestAHBExpressionEvaluation:
             )
         finally:
             inject.clear()
+
+
+class TestAhbExpressionEvaluationWithAhbContext:
+    """
+    End-to-end tests using AhbContext — no inject setup at all.
+    This proves the full pipeline works without the global DI container.
+    """
+
+    @staticmethod
+    def _make_context(
+        rc: dict[str, ConditionFulfilledValue],
+        fc: dict[str, EvaluatedFormatConstraint],
+        hints: dict[str, str],
+    ) -> "AhbContext":
+        from ahbicht.content_evaluation.ahb_context import AhbContext
+
+        cer = ContentEvaluationResult(
+            requirement_constraints=rc,
+            format_constraints=fc,
+            hints=hints,
+        )
+        return AhbContext.from_content_evaluation_result(
+            cer,
+            edifact_format=default_test_format,
+            edifact_format_version=default_test_version,
+        )
+
+    async def test_simple_muss_fulfilled(self):
+        """Muss [1] where [1] is FULFILLED → requirement_indicator=MUSS, fulfilled=True"""
+        ctx = self._make_context(
+            rc={"1": ConditionFulfilledValue.FULFILLED},
+            fc={},
+            hints={},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [1]")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_indicator == ModalMark.MUSS
+        assert result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is True
+
+    async def test_simple_muss_unfulfilled(self):
+        """Muss [1] where [1] is UNFULFILLED → fulfilled=False"""
+        ctx = self._make_context(
+            rc={"1": ConditionFulfilledValue.UNFULFILLED},
+            fc={},
+            hints={},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [1]")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is False
+
+    async def test_and_composition_with_format_constraint(self):
+        """Muss [1] U [2][901] — RC fulfilled, FC fulfilled"""
+        ctx = self._make_context(
+            rc={"1": ConditionFulfilledValue.FULFILLED, "2": ConditionFulfilledValue.FULFILLED},
+            fc={"901": EvaluatedFormatConstraint(format_constraint_fulfilled=True)},
+            hints={},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [1] U [2][901]")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is True
+        assert result.format_constraint_evaluation_result.format_constraints_fulfilled is True
+
+    async def test_or_composition(self):
+        """Muss [1] O [2] — one fulfilled → fulfilled"""
+        ctx = self._make_context(
+            rc={"1": ConditionFulfilledValue.UNFULFILLED, "2": ConditionFulfilledValue.FULFILLED},
+            fc={},
+            hints={},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [1] O [2]")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is True
+
+    async def test_with_hints(self):
+        """Muss [501] — hint key, always neutral → fulfilled with hint text"""
+        ctx = self._make_context(
+            rc={},
+            fc={},
+            hints={"501": "Hinweis 501"},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [501]")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled is True
+        assert result.requirement_constraint_evaluation_result.hints == "Hinweis 501"
+
+    async def test_modal_mark_fallthrough(self):
+        """Muss [1] Kann — first unfulfilled, falls through to Kann"""
+        ctx = self._make_context(
+            rc={"1": ConditionFulfilledValue.UNFULFILLED},
+            fc={},
+            hints={},
+        )
+        tree = await parse_expression_including_unresolved_subexpressions("Muss [1] Kann")
+        result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
+        assert result.requirement_indicator == ModalMark.KANN


### PR DESCRIPTION
## Summary

- `evaluate_ahb_expression_tree(parsed_tree, ahb_context=None)` — the main evaluation entry point now accepts `AhbContext`
- `AhbExpressionTransformer` stores the context and passes it to both `requirement_constraint_evaluation()` and `format_constraint_evaluation()`
- When `ahb_context` is `None`, **no extra kwargs are passed** to downstream functions — preserving compatibility with existing mocks and consumers

## Milestone: full pipeline works without inject

After this PR, you can parse and evaluate an AHB expression **without any inject setup**:

```python
from ahbicht.content_evaluation.ahb_context import AhbContext
from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
from ahbicht.expressions.ahb_expression_evaluation import evaluate_ahb_expression_tree

ctx = AhbContext.from_content_evaluation_result(cer, EdifactFormat.UTILMD, EdifactFormatVersion.FV2210)
tree = await parse_expression_including_unresolved_subexpressions("Muss [1] U [2][901]")
result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
```

## Implementation detail: `rc_kwargs` pattern

Existing tests mock `requirement_constraint_evaluation` with side_effect functions that don't accept `ahb_context`. Passing `ahb_context=None` as a keyword arg would break them. So we only include `ahb_context` in kwargs when it's not None:

```python
rc_kwargs: dict = {}
if self._ahb_context is not None:
    rc_kwargs["ahb_context"] = self._ahb_context
await requirement_constraint_evaluation(condition_expression, **rc_kwargs)
```

## Migration context

PR 6 of the inject removal series. Builds on #745, #746, #747.

**No action required by consumers yet.** Default is `None` = existing inject behavior.

## Test plan

- [x] 6 new end-to-end tests: fulfilled, unfulfilled, AND+FC, OR, hints, modal mark fallthrough — all without inject
- [x] All 539 tests pass (533 existing + 6 new)
- [x] pylint 10/10, mypy clean, isort/black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)