### PR TITLE
feat: thread AhbContext through supporting functions + update notebook

### DIFF
--- a/minimal_working_example.ipynb
+++ b/minimal_working_example.ipynb
@@ -2,6 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "id": "698d93568a879a71",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.331147Z",
+     "start_time": "2025-11-06T14:06:11.137658Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.461959Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.461822Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.533166Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.532640Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "# this is required ONLY in a Jupyter Notebook\n",
     "# otherwise you'll get a \"RuntimeError: Cannot run the event loop while another loop is running\"\n",
@@ -12,46 +31,28 @@
     "from ahbicht.models.mapping_results import PackageKeyConditionExpressionMapping\n",
     "\n",
     "nest_asyncio.apply()  # can be omitted outside jupyter"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.331147Z",
-     "start_time": "2025-11-06T14:06:11.137658Z"
-    }
-   },
-   "id": "698d93568a879a71",
-   "outputs": [],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
-    "from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions\n",
-    "\n",
-    "tree = await parse_expression_including_unresolved_subexpressions(\n",
-    "    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n",
-    "    resolve_packages=False,  # false for now because the PackageResolver is not introduced yet\n",
-    ")  # the expression as you get it from the AHB\n",
-    "print(tree)  # The tree is a data structure that represents the expression\n",
-    "\n",
-    "model_dump_tree(tree)"
-   ],
+   "execution_count": 2,
+   "id": "4a43dc52059980ba",
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2025-11-06T14:06:11.593959Z",
      "start_time": "2025-11-06T14:06:11.499216Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.535043Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.534917Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.580459Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.580065Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "id": "4a43dc52059980ba",
    "outputs": [
     {
      "name": "stdout",
@@ -110,29 +111,39 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 2
+   "source": [
+    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
+    "from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions\n",
+    "\n",
+    "tree = await parse_expression_including_unresolved_subexpressions(\n",
+    "    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n",
+    "    resolve_packages=False,  # false for now because the PackageResolver is not introduced yet\n",
+    ")  # the expression as you get it from the AHB\n",
+    "print(tree)  # The tree is a data structure that represents the expression\n",
+    "\n",
+    "model_dump_tree(tree)"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "# Now, to be honest, this looks pretty lengthy and verbose.\n",
-    "# That's why you can serialize the tree in a more concise way using the so-called \"concise serialization\".\n",
-    "# Note that the concise json dump is _not_ deserializable (yet). So \"concise serialization\" is a one way street so far.\n",
-    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
-    "\n",
-    "model_dump_tree(tree, mode=\"concise\")  # this contains all the relevant information and is pretty concise"
-   ],
+   "execution_count": 3,
+   "id": "cabae178602ec367",
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2025-11-06T14:06:11.617843Z",
      "start_time": "2025-11-06T14:06:11.610Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.581769Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.581650Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.584608Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.584176Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "id": "cabae178602ec367",
    "outputs": [
     {
      "data": {
@@ -151,10 +162,36 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 3
+   "source": [
+    "# Now, to be honest, this looks pretty lengthy and verbose.\n",
+    "# That's why you can serialize the tree in a more concise way using the so-called \"concise serialization\".\n",
+    "# Note that the concise json dump is _not_ deserializable (yet). So \"concise serialization\" is a one way street so far.\n",
+    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
+    "\n",
+    "model_dump_tree(tree, mode=\"concise\")  # this contains all the relevant information and is pretty concise"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
+   "id": "4e4772bf62da629e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.649769Z",
+     "start_time": "2025-11-06T14:06:11.643630Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.585705Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.585590Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.587337Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.586995Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "# As written in the README, ahbicht will _not_ do any content evaluation for you.\n",
     "# You'll need to write your own Evaluator classes for:\n",
@@ -162,23 +199,29 @@
     "# 2. Format Constraints (FC) which describe that data must obey a specified format, e.g. number of post decimal places, MaLo-ID etc.\n",
     "# 3. Hints: \"Hinweise\", plain text which is passed through\n",
     "# 4. Packages: From 2022-10-01 it is possible to abbreviate frequently used expressions in \"packages\"."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.649769Z",
-     "start_time": "2025-11-06T14:06:11.643630Z"
-    }
-   },
-   "id": "4e4772bf62da629e",
-   "outputs": [],
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "id": "b1c7fb302827603",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.704373Z",
+     "start_time": "2025-11-06T14:06:11.673365Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.588284Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.588177Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.600616Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.600210Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "from ahbicht.content_evaluation.rc_evaluators import RcEvaluator\n",
     "from maus.edifact import EdifactFormat, EdifactFormatVersion\n",
@@ -227,23 +270,29 @@
     "\n",
     "    def evaluate_9(self, _, __):\n",
     "        return ConditionFulfilledValue.FULFILLED"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.704373Z",
-     "start_time": "2025-11-06T14:06:11.673365Z"
-    }
-   },
-   "id": "b1c7fb302827603",
-   "outputs": [],
-   "execution_count": 5
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "id": "2ee77f92ab527b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.725379Z",
+     "start_time": "2025-11-06T14:06:11.717280Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.601855Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.601739Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.604510Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.604159Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "# now we do the same thing for the format constraints\n",
     "from ahbicht.models.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint\n",
@@ -279,23 +328,29 @@
     "            format_constraint_fulfilled=False,\n",
     "            error_message=f\"The input '{entered_input['data']}' does not obey format constraint 901.\",\n",
     "        )"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.725379Z",
-     "start_time": "2025-11-06T14:06:11.717280Z"
-    }
-   },
-   "id": "2ee77f92ab527b",
-   "outputs": [],
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
+   "id": "e5c3d40d8828cf48",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.749981Z",
+     "start_time": "2025-11-06T14:06:11.744820Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.605815Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.605704Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.608593Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.608259Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "from ahbicht.expressions.package_expansion import PackageResolver\n",
     "\n",
@@ -338,23 +393,29 @@
     "        return PackageKeyConditionExpressionMapping(\n",
     "            package_key=package_key, package_expression=None, edifact_format=EdifactFormat.UTILMD\n",
     "        )"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.749981Z",
-     "start_time": "2025-11-06T14:06:11.744820Z"
-    }
-   },
-   "id": "e5c3d40d8828cf48",
-   "outputs": [],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
+   "id": "148291c526bd354d",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.775701Z",
+     "start_time": "2025-11-06T14:06:11.769243Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.609603Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.609497Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.611534Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.611158Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "# we'll just provide some hard coded data here for demonstration purposes\n",
     "hardcoded_content_evaluations = {\n",
@@ -370,23 +431,29 @@
     "    edifact_format=EdifactFormat.UTILMD,  # format and format version may be used to select the appropriate evaluator instance\n",
     "    edifact_format_version=EdifactFormatVersion.FV2104,\n",
     ")  # this is the data that, in real life, contains the content of the edifact message."
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.775701Z",
-     "start_time": "2025-11-06T14:06:11.769243Z"
-    }
-   },
-   "id": "148291c526bd354d",
-   "outputs": [],
-   "execution_count": 8
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "id": "9e6ae7ff89e66f88",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.810899Z",
+     "start_time": "2025-11-06T14:06:11.793334Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.612561Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.612461Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.622825Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.621882Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "from ahbicht.content_evaluation.token_logic_provider import SingletonTokenLogicProvider, TokenLogicProvider\n",
     "import inject\n",
@@ -434,46 +501,28 @@
     "# Now the context variable is set and ready to be used by the FC evaluator.\n",
     "\n",
     "expression_evaluation_result = await evaluate_ahb_expression_tree(tree)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.810899Z",
-     "start_time": "2025-11-06T14:06:11.793334Z"
-    }
-   },
-   "id": "9e6ae7ff89e66f88",
-   "outputs": [],
-   "execution_count": 9
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "print(f\"It's actually a '{expression_evaluation_result.requirement_indicator}'field.\")\n",
-    "if expression_evaluation_result.format_constraint_evaluation_result.format_constraints_fulfilled:\n",
-    "    print(f\"The format constraint is fulfilled => Data are ok.\")\n",
-    "else:\n",
-    "    print(\n",
-    "        f'The format constraint is _not_ fulfilled: \"{expression_evaluation_result.format_constraint_evaluation_result.error_message}\"'\n",
-    "    )\n",
-    "print(\n",
-    "    f'Please note the following hint: \"{expression_evaluation_result.requirement_constraint_evaluation_result.hints}\"'\n",
-    ")"
-   ],
+   "execution_count": 10,
+   "id": "615a5292492df138",
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2025-11-06T14:06:11.837938Z",
      "start_time": "2025-11-06T14:06:11.831078Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.628004Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.627868Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.631496Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.630866Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "id": "615a5292492df138",
    "outputs": [
     {
      "name": "stdout",
@@ -485,30 +534,145 @@
      ]
     }
    ],
-   "execution_count": 10
+   "source": [
+    "print(f\"It's actually a '{expression_evaluation_result.requirement_indicator}'field.\")\n",
+    "if expression_evaluation_result.format_constraint_evaluation_result.format_constraints_fulfilled:\n",
+    "    print(f\"The format constraint is fulfilled => Data are ok.\")\n",
+    "else:\n",
+    "    print(\n",
+    "        f'The format constraint is _not_ fulfilled: \"{expression_evaluation_result.format_constraint_evaluation_result.error_message}\"'\n",
+    "    )\n",
+    "print(\n",
+    "    f'Please note the following hint: \"{expression_evaluation_result.requirement_constraint_evaluation_result.hints}\"'\n",
+    ")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "e16b0a31",
-   "source": "## Simpler alternative: AhbContext (no inject setup needed)\n\nStarting with ahbicht v1.3.0, you can use `AhbContext` instead of the inject-based setup above.\n`AhbContext` bundles all evaluators and data into a single object that you pass explicitly — no global state, no dependency injection framework.\n\nThis is especially useful when:\n- You already have pre-computed `ContentEvaluationResult` data (e.g. in a REST API)\n- You want simpler, more explicit code\n- You need to evaluate different expressions with different contexts (no global state to juggle)",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Simpler alternative: AhbContext (no inject setup needed)\n",
+    "\n",
+    "Starting with ahbicht v1.3.0, you can use `AhbContext` instead of the inject-based setup above.\n",
+    "`AhbContext` bundles all evaluators and data into a single object that you pass explicitly — no global state, no dependency injection framework.\n",
+    "\n",
+    "This is especially useful when:\n",
+    "- You already have pre-computed `ContentEvaluationResult` data (e.g. in a REST API)\n",
+    "- You want simpler, more explicit code\n",
+    "- You need to evaluate different expressions with different contexts (no global state to juggle)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "id": "77b8ac7a",
-   "source": "from ahbicht.content_evaluation.ahb_context import AhbContext\nfrom ahbicht.models.content_evaluation_result import ContentEvaluationResult\n\n# 1. Put all your known evaluation results into a ContentEvaluationResult\ncer = ContentEvaluationResult(\n    hints={\"555\": \"Hinweis 555 applies.\"},\n    format_constraints={\n        \"901\": EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None),\n    },\n    requirement_constraints={\n        \"2\": ConditionFulfilledValue.FULFILLED,\n        \"3\": ConditionFulfilledValue.UNFULFILLED,\n        \"4\": ConditionFulfilledValue.FULFILLED,\n        \"8\": ConditionFulfilledValue.FULFILLED,\n        \"9\": ConditionFulfilledValue.FULFILLED,\n    },\n    packages={\"123P\": \"[8] U [9]\"},\n)\n\n# 2. Create an AhbContext from it — one line, no inject, no TokenLogicProvider, no EvaluatableDataProvider\nctx = AhbContext.from_content_evaluation_result(cer, EdifactFormat.UTILMD, EdifactFormatVersion.FV2104)\n\n# 3. Parse and evaluate — pass the context explicitly\ntree = await parse_expression_including_unresolved_subexpressions(\n    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n    resolve_packages=True,\n    ahb_context=ctx,\n)\nresult = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)\n\nprint(f\"Requirement indicator: {result.requirement_indicator}\")\nprint(f\"RC fulfilled: {result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled}\")\nprint(f\"FC fulfilled: {result.format_constraint_evaluation_result.format_constraints_fulfilled}\")\nprint(f\"Hints: {result.requirement_constraint_evaluation_result.hints}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.632913Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.632772Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.646656Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.640105Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement indicator: MUSS\n",
+      "RC fulfilled: True\n",
+      "FC fulfilled: True\n",
+      "Hints: Hinweis 555 applies.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ahbicht.content_evaluation.ahb_context import AhbContext\n",
+    "from ahbicht.models.content_evaluation_result import ContentEvaluationResult\n",
+    "\n",
+    "# 1. Put all your known evaluation results into a ContentEvaluationResult\n",
+    "cer = ContentEvaluationResult(\n",
+    "    hints={\"555\": \"Hinweis 555 applies.\"},\n",
+    "    format_constraints={\n",
+    "        \"901\": EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None),\n",
+    "    },\n",
+    "    requirement_constraints={\n",
+    "        \"2\": ConditionFulfilledValue.FULFILLED,\n",
+    "        \"3\": ConditionFulfilledValue.UNFULFILLED,\n",
+    "        \"4\": ConditionFulfilledValue.FULFILLED,\n",
+    "        \"8\": ConditionFulfilledValue.FULFILLED,\n",
+    "        \"9\": ConditionFulfilledValue.FULFILLED,\n",
+    "    },\n",
+    "    packages={\"123P\": \"[8] U [9]\"},\n",
+    ")\n",
+    "\n",
+    "# 2. Create an AhbContext from it — one line, no inject, no TokenLogicProvider, no EvaluatableDataProvider\n",
+    "ctx = AhbContext.from_content_evaluation_result(cer, EdifactFormat.UTILMD, EdifactFormatVersion.FV2104)\n",
+    "\n",
+    "# 3. Parse and evaluate — pass the context explicitly\n",
+    "tree = await parse_expression_including_unresolved_subexpressions(\n",
+    "    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n",
+    "    resolve_packages=True,\n",
+    "    ahb_context=ctx,\n",
+    ")\n",
+    "result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)\n",
+    "\n",
+    "print(f\"Requirement indicator: {result.requirement_indicator}\")\n",
+    "print(f\"RC fulfilled: {result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled}\")\n",
+    "print(f\"FC fulfilled: {result.format_constraint_evaluation_result.format_constraints_fulfilled}\")\n",
+    "print(f\"Hints: {result.requirement_constraint_evaluation_result.hints}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "fd6def50",
-   "source": "You can also create an `AhbContext` with custom evaluator instances (for on-demand evaluation, e.g. in a message validator like wanna.bee):\n\n```python\nctx = AhbContext(\n    rc_evaluator=MyRequirementConstraintEvaluator(),\n    fc_evaluator=MyFormatConstraintEvaluator(),\n    hints_provider=MyHintsProvider(),\n    package_resolver=MyPackageResolver(),\n    evaluatable_data=my_evaluatable_data,\n)\n```\n\nBoth approaches produce the same result. The `AhbContext` approach is the recommended way going forward; the inject-based approach shown above will be deprecated in a future version.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "You can also create an `AhbContext` with custom evaluator instances (for on-demand evaluation, e.g. in a message validator like wanna.bee):\n",
+    "\n",
+    "```python\n",
+    "ctx = AhbContext(\n",
+    "    rc_evaluator=MyRequirementConstraintEvaluator(),\n",
+    "    fc_evaluator=MyFormatConstraintEvaluator(),\n",
+    "    hints_provider=MyHintsProvider(),\n",
+    "    package_resolver=MyPackageResolver(),\n",
+    "    evaluatable_data=my_evaluatable_data,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Both approaches produce the same result. The `AhbContext` approach is the recommended way going forward; the inject-based approach shown above will be deprecated in a future version."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "id": "8955615de55db6ba",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:11.867253Z",
+     "start_time": "2025-11-06T14:06:11.856906Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.648343Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.648188Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.652571Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.652156Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "requirement_indicator=<ModalMark.MUSS: 'MUSS'> requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo') format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None)\n"
+     ]
+    }
+   ],
    "source": [
     "# If writing the RcEvaluator+FcEvaluator+HintsProvider+PackageResolver feels like over-engineering for your use case, we have you covered.\n",
     "# If you already know the values of the single requirement constraints, format constraints and texts for the hint, you can just generate the Evaluator classes on the fly based on the information you have.\n",
@@ -539,50 +703,28 @@
     ")  # this does all the magic, no need to manually define classes\n",
     "evaluated = await evaluate_ahb_expression_tree(tree)\n",
     "print(evaluated)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:11.867253Z",
-     "start_time": "2025-11-06T14:06:11.856906Z"
-    }
-   },
-   "id": "8955615de55db6ba",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "requirement_indicator=<ModalMark.MUSS: 'MUSS'> requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo') format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None)\n"
-     ]
-    }
-   ],
-   "execution_count": 11
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "# Now, if your main application is not written in Python and you cannot/must not host AHBicht anywhere or don't want to use our public AHBicht REST API:\n",
-    "# There is a simple way to pre-calculate all possible outcomes of an expression in advance:\n",
-    "from ahbicht.expressions.condition_expression_parser import extract_categorized_keys\n",
-    "\n",
-    "categorized_key_extract = await extract_categorized_keys(\"Muss [2] U ([3] O [4])[901] U [555]\")\n",
-    "print(categorized_key_extract)"
-   ],
+   "execution_count": 13,
+   "id": "32c7bc323a89056",
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2025-11-06T14:06:11.919559Z",
      "start_time": "2025-11-06T14:06:11.907692Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.653759Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.653646Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.663007Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.661868Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "id": "32c7bc323a89056",
    "outputs": [
     {
      "name": "stdout",
@@ -592,25 +734,35 @@
      ]
     }
    ],
-   "execution_count": 12
+   "source": [
+    "# Now, if your main application is not written in Python and you cannot/must not host AHBicht anywhere or don't want to use our public AHBicht REST API:\n",
+    "# There is a simple way to pre-calculate all possible outcomes of an expression in advance:\n",
+    "from ahbicht.expressions.condition_expression_parser import extract_categorized_keys\n",
+    "\n",
+    "categorized_key_extract = await extract_categorized_keys(\"Muss [2] U ([3] O [4])[901] U [555]\")\n",
+    "print(categorized_key_extract)"
+   ]
   },
   {
    "cell_type": "code",
-   "source": [
-    "precalculated_results = categorized_key_extract.generate_possible_content_evaluation_results()\n",
-    "print(len(precalculated_results))  # <-- this contains 128 possible ContentEvaluationResults"
-   ],
+   "execution_count": 14,
+   "id": "78d6d08a26b2ab3b",
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
     "ExecuteTime": {
      "end_time": "2025-11-06T14:06:11.960672Z",
      "start_time": "2025-11-06T14:06:11.952378Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.664359Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.664236Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.666924Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.666573Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
     }
    },
-   "id": "78d6d08a26b2ab3b",
    "outputs": [
     {
      "name": "stdout",
@@ -620,10 +772,40 @@
      ]
     }
    ],
-   "execution_count": 13
+   "source": [
+    "precalculated_results = categorized_key_extract.generate_possible_content_evaluation_results()\n",
+    "print(len(precalculated_results))  # <-- this contains 128 possible ContentEvaluationResults"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
+   "id": "441d6c142a5c282b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-11-06T14:06:12.061845Z",
+     "start_time": "2025-11-06T14:06:12.010106Z"
+    },
+    "collapsed": false,
+    "execution": {
+     "iopub.execute_input": "2026-04-12T13:52:33.668112Z",
+     "iopub.status.busy": "2026-04-12T13:52:33.668001Z",
+     "iopub.status.idle": "2026-04-12T13:52:33.693241Z",
+     "shell.execute_reply": "2026-04-12T13:52:33.692792Z"
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(ContentEvaluationResult(hints={'555': 'Hinweis 555'}, format_constraints={'901': EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)}, requirement_constraints={'2': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '3': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '4': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>}, packages={}, id=None), AhbExpressionEvaluationResult(requirement_indicator=<ModalMark.MUSS: 'MUSS'>, requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None))), (ContentEvaluationResult(hints={'555': 'Hinweis 555'}, format_constraints={'901': EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)}, requirement_constraints={'2': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '3': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '4': <ConditionFulfilledValue.UNFULFILLED: 'UNFULFILLED'>}, packages={}, id=None), AhbExpressionEvaluationResult(requirement_indicator=<ModalMark.MUSS: 'MUSS'>, requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None)))]\n"
+     ]
+    }
+   ],
    "source": [
     "results = list()\n",
     "for content_evaluation_result in precalculated_results:\n",
@@ -643,28 +825,7 @@
     "    results.append((content_evaluation_result, expression_evaluation_result))\n",
     "    # export the result with expression_evaluation_result and the content_evaluation_result and deserialize them in your non-python application\n",
     "print(results[0:2])"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    },
-    "ExecuteTime": {
-     "end_time": "2025-11-06T14:06:12.061845Z",
-     "start_time": "2025-11-06T14:06:12.010106Z"
-    }
-   },
-   "id": "441d6c142a5c282b",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[(ContentEvaluationResult(hints={'555': 'Hinweis 555'}, format_constraints={'901': EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)}, requirement_constraints={'2': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '3': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '4': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>}, packages={}, id=None), AhbExpressionEvaluationResult(requirement_indicator=<ModalMark.MUSS: 'MUSS'>, requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None))), (ContentEvaluationResult(hints={'555': 'Hinweis 555'}, format_constraints={'901': EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)}, requirement_constraints={'2': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '3': <ConditionFulfilledValue.FULFILLED: 'FULFILLED'>, '4': <ConditionFulfilledValue.UNFULFILLED: 'UNFULFILLED'>}, packages={}, id=None), AhbExpressionEvaluationResult(requirement_indicator=<ModalMark.MUSS: 'MUSS'>, requirement_constraint_evaluation_result=RequirementConstraintEvaluationResult(requirement_constraints_fulfilled=True, requirement_is_conditional=True, format_constraints_expression='[901]', hints='foo'), format_constraint_evaluation_result=FormatConstraintEvaluationResult(format_constraints_fulfilled=True, error_message=None)))]\n"
-     ]
-    }
-   ],
-   "execution_count": 14
+   ]
   }
  ],
  "metadata": {
@@ -683,7 +844,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/minimal_working_example.ipynb
+++ b/minimal_working_example.ipynb
@@ -488,6 +488,26 @@
    "execution_count": 10
   },
   {
+   "cell_type": "markdown",
+   "id": "e16b0a31",
+   "source": "## Simpler alternative: AhbContext (no inject setup needed)\n\nStarting with ahbicht v1.3.0, you can use `AhbContext` instead of the inject-based setup above.\n`AhbContext` bundles all evaluators and data into a single object that you pass explicitly — no global state, no dependency injection framework.\n\nThis is especially useful when:\n- You already have pre-computed `ContentEvaluationResult` data (e.g. in a REST API)\n- You want simpler, more explicit code\n- You need to evaluate different expressions with different contexts (no global state to juggle)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "77b8ac7a",
+   "source": "from ahbicht.content_evaluation.ahb_context import AhbContext\nfrom ahbicht.models.content_evaluation_result import ContentEvaluationResult\n\n# 1. Put all your known evaluation results into a ContentEvaluationResult\ncer = ContentEvaluationResult(\n    hints={\"555\": \"Hinweis 555 applies.\"},\n    format_constraints={\n        \"901\": EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None),\n    },\n    requirement_constraints={\n        \"2\": ConditionFulfilledValue.FULFILLED,\n        \"3\": ConditionFulfilledValue.UNFULFILLED,\n        \"4\": ConditionFulfilledValue.FULFILLED,\n        \"8\": ConditionFulfilledValue.FULFILLED,\n        \"9\": ConditionFulfilledValue.FULFILLED,\n    },\n    packages={\"123P\": \"[8] U [9]\"},\n)\n\n# 2. Create an AhbContext from it — one line, no inject, no TokenLogicProvider, no EvaluatableDataProvider\nctx = AhbContext.from_content_evaluation_result(cer, EdifactFormat.UTILMD, EdifactFormatVersion.FV2104)\n\n# 3. Parse and evaluate — pass the context explicitly\ntree = await parse_expression_including_unresolved_subexpressions(\n    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n    resolve_packages=True,\n    ahb_context=ctx,\n)\nresult = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)\n\nprint(f\"Requirement indicator: {result.requirement_indicator}\")\nprint(f\"RC fulfilled: {result.requirement_constraint_evaluation_result.requirement_constraints_fulfilled}\")\nprint(f\"FC fulfilled: {result.format_constraint_evaluation_result.format_constraints_fulfilled}\")\nprint(f\"Hints: {result.requirement_constraint_evaluation_result.hints}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd6def50",
+   "source": "You can also create an `AhbContext` with custom evaluator instances (for on-demand evaluation, e.g. in a message validator like wanna.bee):\n\n```python\nctx = AhbContext(\n    rc_evaluator=MyRequirementConstraintEvaluator(),\n    fc_evaluator=MyFormatConstraintEvaluator(),\n    hints_provider=MyHintsProvider(),\n    package_resolver=MyPackageResolver(),\n    evaluatable_data=my_evaluatable_data,\n)\n```\n\nBoth approaches produce the same result. The `AhbContext` approach is the recommended way going forward; the inject-based approach shown above will be deprecated in a future version.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "source": [
     "# If writing the RcEvaluator+FcEvaluator+HintsProvider+PackageResolver feels like over-engineering for your use case, we have you covered.\n",

--- a/src/ahbicht/content_evaluation/expression_check.py
+++ b/src/ahbicht/content_evaluation/expression_check.py
@@ -2,8 +2,10 @@
 contains a high-level function that checks if a given expression is valid or not.
 """
 
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Awaitable, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Optional, Union
 
 from lark import Token, Tree
 from lark.exceptions import UnexpectedCharacters, VisitError
@@ -14,10 +16,14 @@ from ahbicht.expressions.condition_expression_parser import extract_categorized_
 from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions
 from ahbicht.models.content_evaluation_result import ContentEvaluationResult
 
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
+
 
 async def is_valid_expression(
     expression_or_tree: Union[str, Tree[Token]],
     content_evaluation_result_setter: Callable[[ContentEvaluationResult], Any],
+    ahb_context: Optional[AhbContext] = None,
 ) -> tuple[bool, Optional[str]]:
     """
     Returns true iff the given expression is both well-formed and valid.
@@ -33,7 +39,9 @@ async def is_valid_expression(
     tree: Tree[Token]
     if isinstance(expression_or_tree, str):
         try:
-            tree = await parse_expression_including_unresolved_subexpressions(expression_or_tree)
+            tree = await parse_expression_including_unresolved_subexpressions(
+                expression_or_tree, ahb_context=ahb_context
+            )
         except SyntaxError as syntax_error:
             return False, str(syntax_error)
         except VisitError as visit_error:
@@ -45,15 +53,19 @@ async def is_valid_expression(
     else:
         raise ValueError(f"{expression_or_tree} is neither a string nor a Tree")
     categorized_key_extract = extract_categorized_keys_from_tree(tree, sanitize=True)
+    context_kwargs: dict = {}
+    if ahb_context is not None:
+        context_kwargs["ahb_context"] = ahb_context
     evaluation_tasks: list[Awaitable] = []
     for content_evaluation_result in categorized_key_extract.generate_possible_content_evaluation_results():
         # create (but do not await) the evaluation tasks for all possible content evaluation results
         # the idea is, that if _any_ evaluation task raises an uncatched exception this can be interpreted as:
         # "the expression is invalid"
+
         async def evaluate_with_cer(cer: ContentEvaluationResult):
             content_evaluation_result_setter(cer)
             try:
-                await evaluate_ahb_expression_tree(tree)
+                await evaluate_ahb_expression_tree(tree, **context_kwargs)
             except NotImplementedError as not_implemented_error:
                 # we can ignore some specific errors
                 if "due to missing information" in str(not_implemented_error):

--- a/src/ahbicht/expressions/condition_expression_parser.py
+++ b/src/ahbicht/expressions/condition_expression_parser.py
@@ -6,8 +6,10 @@ The used terms are defined in the README_conditions.md.
 """
 
 # pylint:disable=cyclic-import
+from __future__ import annotations
+
 from functools import lru_cache
-from typing import Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from lark import Lark, Token, Tree
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF
@@ -18,6 +20,9 @@ from ahbicht.expressions.sanitizer import sanitize_expression
 from ahbicht.models.categorized_key_extract import CategorizedKeyExtract
 from ahbicht.models.condition_node_type import ConditionNodeType
 from ahbicht.utility_functions import tree_copy
+
+if TYPE_CHECKING:
+    from ahbicht.content_evaluation.ahb_context import AhbContext
 
 GRAMMAR = r"""
 ?expression: expression "O"i expression -> or_composition
@@ -141,10 +146,12 @@ async def extract_categorized_keys(
     resolve_packages: bool = False,
     resolve_time_conditions: bool = False,
     replace_time_conditions: bool = False,
+    ahb_context: Optional[AhbContext] = None,
 ) -> CategorizedKeyExtract:
     """
     Parses the given condition expression and returns CategorizedKeyExtract as a template for content
     evaluation.
+    :param ahb_context: optional AhbContext; if provided, bypasses the global inject container
     """
     # because of
     # ImportError: cannot import name 'parse_condition_expression_to_tree' from partially initialized module
@@ -157,5 +164,6 @@ async def extract_categorized_keys(
         resolve_packages=resolve_packages,
         resolve_time_conditions=resolve_time_conditions,
         replace_time_conditions=replace_time_conditions,
+        ahb_context=ahb_context,
     )
     return extract_categorized_keys_from_tree(tree, sanitize=True)


### PR DESCRIPTION
## Summary

- `extract_categorized_keys()` now accepts `ahb_context: Optional[AhbContext] = None`
- `is_valid_expression()` now accepts `ahb_context: Optional[AhbContext] = None`
- Jupyter notebook updated with new section demonstrating AhbContext usage

## Migration context

PR 7 (final) of the inject removal migration series. After this PR, **all public entry points** accept `ahb_context`:

| Function | File |
|----------|------|
| `parse_expression_including_unresolved_subexpressions` | expression_resolver.py |
| `evaluate_ahb_expression_tree` | ahb_expression_evaluation.py |
| `extract_categorized_keys` | condition_expression_parser.py |
| `is_valid_expression` | expression_check.py |

### For consumers: how to migrate

```python
from ahbicht.content_evaluation.ahb_context import AhbContext

# Create context from pre-computed results (simplest path)
ctx = AhbContext.from_content_evaluation_result(cer, format, format_version)

# Pass it to any ahbicht function
tree = await parse_expression_including_unresolved_subexpressions(expr, ahb_context=ctx)
result = await evaluate_ahb_expression_tree(tree, ahb_context=ctx)
```

No inject setup, no ContextVars, no TokenLogicProvider, no EvaluatableDataProvider.

**Ready for v1.3.0 release after merge.**

## Test plan

- [x] All 539 tests pass
- [x] pylint 10/10
- [x] isort/black clean
- [x] Notebook updated with AhbContext section

🤖 Generated with [Claude Code](https://claude.com/claude-code)