### PR TITLE
fix: repair sphinx docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,16 +47,7 @@ except FileNotFoundError:
     pass
 
 try:
-    import sphinx
-    from pkg_resources import parse_version
-
-    cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
-    cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
-
-    args = cmd_line.split(" ")
-    if parse_version(sphinx.__version__) >= parse_version("1.7"):
-        args = args[1:]
-
+    args = ["-f", "-o", output_dir, module_dir]
     apidoc.main(args)
 except Exception as e:
     print("Running `sphinx-apidoc` failed!\n{}".format(e))


### PR DESCRIPTION
## Summary
- The sphinx-apidoc step in `docs/conf.py` used `from pkg_resources import parse_version` to check for Sphinx >= 1.7
- `setuptools` is not in the docs dependencies, so the import fails silently (caught by bare `except`), `sphinx-apidoc` never runs, and `docs/api/modules.rst` is never created — breaking the toctree reference
- The version check was for Sphinx 1.7 but we use 8.1.3, so it was always true
- Fix: remove the dead code and call `apidoc.main()` directly

## Test plan
- [x] `sphinx-build -W -b html` succeeds locally with zero warnings
- [ ] CI "Check Docs" job passes (was failing on every PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)