### PR TITLE
fix: InvalidExpressionError should inherit from Exception, not BaseException

### DIFF
--- a/src/ahbicht/expressions/__init__.py
+++ b/src/ahbicht/expressions/__init__.py
@@ -9,10 +9,15 @@ parsing_logger = logging.getLogger("ahbicht.expressions")
 parsing_logger.setLevel(logging.DEBUG)
 
 
-class InvalidExpressionError(BaseException):
+class InvalidExpressionError(Exception):
     """
     Is raised when an expression is well-formed but invalid.
     A syntactical error leads to a SyntaxError during parsing with lark whereas this exception occurs during evaluation.
+
+    Inherits from :class:`Exception` (not :class:`BaseException`) so that ordinary ``except Exception`` guards -- as
+    used by web frameworks, ASGI servers and task groups -- catch it. Inheriting from ``BaseException`` made this
+    validation error bypass those guards and propagate like ``KeyboardInterrupt``/``SystemExit``, which could tear
+    down an entire ASGI/anyio task group instead of failing the single request. See Hochfrequenz/ahbicht-functions#732.
     """
 
     def __init__(self, error_message: str, invalid_expression: Optional[str] = None) -> None:

--- a/unittests/test_requirement_constraint_expression_evaluation.py
+++ b/unittests/test_requirement_constraint_expression_evaluation.py
@@ -323,6 +323,15 @@ class TestRequirementConstraintEvaluation:
 
         assert """is not implemented as it has no useful result.""" in str(excinfo.value)
 
+    def test_invalid_expression_error_is_an_exception(self) -> None:
+        """
+        InvalidExpressionError must inherit from Exception (not BaseException) so that ordinary
+        ``except Exception`` guards in web frameworks, ASGI servers and task groups catch it instead of it
+        propagating like KeyboardInterrupt/SystemExit and tearing down whole task groups.
+        See https://github.com/Hochfrequenz/ahbicht-functions/issues/732
+        """
+        assert issubclass(InvalidExpressionError, Exception)
+
     @pytest.mark.parametrize(
         "input_values, expected_evaluated_result",
         [


### PR DESCRIPTION
## What

Change `InvalidExpressionError` to inherit from `Exception` instead of `BaseException`.

Closes #810.

## Why

`InvalidExpressionError` is a recoverable domain/validation error raised during evaluation (e.g. combining a `NEUTRAL` element with a boolean value in an `O`/`X` composition). Callers are expected to catch it — ahbicht itself does, in `content_evaluation/expression_check.py`.

Inheriting from `BaseException` made it **bypass ordinary `except Exception` guards** used by web frameworks, ASGI servers and `asyncio`/`anyio` task groups. It propagated like `KeyboardInterrupt`/`SystemExit`, and when ahbicht runs behind an ASGI app (FastAPI + FastMCP), it tore down the entire server task group — every subsequent request failed until restart. Full downstream report: Hochfrequenz/ahbicht-functions#732.

`InvalidExpressionError` is the only `BaseException` subclass in the codebase; every other error is a normal `Exception`.

## Backwards compatibility

- `except InvalidExpressionError` and `pytest.raises(InvalidExpressionError)` are unchanged.
- ahbicht's own `except InvalidExpressionError` in `expression_check.py` is unaffected.
- The only behavioural change is the intended one: `except Exception` now catches it.

## Tests

Added `test_invalid_expression_error_is_an_exception` asserting `issubclass(InvalidExpressionError, Exception)`, next to the existing `test_hints_and_formats_with_invalid_or_xor_composition` that exercises the raising path.
