### PR TITLE
Migrate dev tooling from black/isort/pylint to ruff

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,11 +6,22 @@ on:
   pull_request: {}
 jobs:
   black:
+    # Job id and matrix values ("black"/"isort") are kept as-is, even though both now run ruff under the hood,
+    # because they are required status checks in branch protection. Renaming them requires updating branch
+    # protection's required-status-check list in the same change - see the `command` entries below for what
+    # actually runs. The explicit `name:` below only interpolates python-version/tool (not `command`) so the
+    # reported check names stay byte-identical to what branch protection expects.
+    name: "black (${{ matrix.python-version }}, ${{ matrix.tool }})"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.14"]
         tool: ["black", "isort"]
+        include:
+          - tool: black
+            command: "ruff format --check ."
+          - tool: isort
+            command: "ruff check --select I ."
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
@@ -18,6 +29,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --group formatting
+        run: uv sync --group linting
       - name: ${{ matrix.tool }} Code Formatter
-        run: uv run ${{ matrix.tool }} . --check
+        run: uv run ${{ matrix.command }}

--- a/.github/workflows/pythonlint.yml
+++ b/.github/workflows/pythonlint.yml
@@ -19,11 +19,11 @@ jobs:
           python-version: "3.14"
       - name: Install Dependencies
         run: uv sync --group ${{ matrix.linter-env }}
-      - name: Run pylint
+      - name: Run ruff
         if: matrix.linter-env == 'linting'
         run: |
-          uv run pylint src/ahbicht
-          uv run pylint json_schemas/generate_json_schemas.py
+          uv run ruff check src/ahbicht
+          uv run ruff check json_schemas/generate_json_schemas.py
       - name: Run mypy
         if: matrix.linter-env == 'type_check'
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,19 +9,10 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 26.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.0
     hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-      - id: isort
-        name: isort (cython)
-        types: [cython]
-      - id: isort
-        name: isort (pyi)
-        types: [pyi]
+      - id: ruff-check
+        args: [--fix]
+        files: ^(src/ahbicht|json_schemas/generate_json_schemas\.py)
+      - id: ruff-format

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Code Quality / Production Readiness
 -----------------------------------
 
 -  The code has at least a 95% unit test coverage. ✔️
--  The code is rated 10/10 in pylint and type checked with mypy. ✔️
+-  The code is linted with ruff and type checked with mypy. ✔️
 -  The code is `MIT licensed <LICENSE>`__. ✔️
 -  There are only `few dependencies <requirements.in>`__. ✔️
 

--- a/json_schemas/generate_json_schemas.py
+++ b/json_schemas/generate_json_schemas.py
@@ -5,7 +5,7 @@ It creates json schema files as described in the README.md in the same directory
 
 import json
 import pathlib
-from typing import Any, Type
+from typing import Any
 
 from pydantic import BaseModel, TypeAdapter
 
@@ -19,7 +19,7 @@ from ahbicht.models.evaluation_results import (
 )
 from ahbicht.models.mapping_results import ConditionKeyConditionTextMapping, PackageKeyConditionExpressionMapping
 
-schema_types: list[Type[TypeAdapter[Any]] | Type[BaseModel]] = [
+schema_types: list[type[TypeAdapter[Any]] | type[BaseModel]] = [
     RequirementConstraintEvaluationResult,  # pydantic
     FormatConstraintEvaluationResult,  # pydantic
     EvaluatedFormatConstraint,  # pydantic

--- a/minimal_working_example.ipynb
+++ b/minimal_working_example.ipynb
@@ -112,8 +112,8 @@
     }
    ],
    "source": [
-    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
     "from ahbicht.expressions.expression_resolver import parse_expression_including_unresolved_subexpressions\n",
+    "from ahbicht.json_serialization.tree_schema import model_dump_tree\n",
     "\n",
     "tree = await parse_expression_including_unresolved_subexpressions(\n",
     "    \"Muss [2] U (([3] O [4]) U [123P])[901] U [555]\",\n",
@@ -223,9 +223,10 @@
    },
    "outputs": [],
    "source": [
-    "from ahbicht.content_evaluation.rc_evaluators import RcEvaluator\n",
     "from efoli import EdifactFormat, EdifactFormatVersion\n",
-    "from ahbicht.content_evaluation.evaluationdatatypes import EvaluationContext, EvaluatableData\n",
+    "\n",
+    "from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, EvaluationContext\n",
+    "from ahbicht.content_evaluation.rc_evaluators import RcEvaluator\n",
     "\n",
     "\n",
     "class MyRequirementConstraintEvaluator(RcEvaluator):\n",
@@ -295,8 +296,8 @@
    "outputs": [],
    "source": [
     "# now we do the same thing for the format constraints\n",
-    "from ahbicht.models.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint\n",
     "from ahbicht.content_evaluation.fc_evaluators import FcEvaluator\n",
+    "from ahbicht.models.condition_nodes import ConditionFulfilledValue, EvaluatedFormatConstraint\n",
     "\n",
     "\n",
     "class MyFormatConstraintEvaluator(FcEvaluator):\n",
@@ -352,10 +353,9 @@
    },
    "outputs": [],
    "source": [
-    "from ahbicht.expressions.package_expansion import PackageResolver\n",
-    "\n",
     "# we also define a hints provider\n",
     "from ahbicht.expressions.hints_provider import HintsProvider\n",
+    "from ahbicht.expressions.package_expansion import PackageResolver\n",
     "\n",
     "\n",
     "class MyHintsProvider(HintsProvider):\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,14 +42,13 @@ tests = [
     "pytest-datafiles==3.0.1",
     "pytest-mock==3.15.1",
 ]
-linting = ["pylint==4.0.6"]
+linting = ["ruff==0.16.0"]
 type_check = [
     "mypy[pydantic]==2.3.0",
     "types-pytz==2026.3.1.20260727",
     { include-group = "tests" },
 ]
 coverage = ["coverage==7.15.2", { include-group = "tests" }]
-formatting = ["black[jupyter]==26.5.1", "isort==8.0.1"]
 spellcheck = ["codespell==2.4.3"]
 docs = ["sphinx==8.1.3", "sphinx-rtd-theme==3.1.0"]
 json_schemas = []
@@ -60,7 +59,6 @@ dev = [
     { include-group = "linting" },
     { include-group = "type_check" },
     { include-group = "coverage" },
-    { include-group = "formatting" },
     { include-group = "spellcheck" },
     { include-group = "docs" },
     { include-group = "json_schemas" },
@@ -69,16 +67,32 @@ dev = [
 [tool.uv]
 default-groups = []
 
-[tool.black]
+[tool.ruff]
 line-length = 120
+extend-exclude = ["*.md"]
 
-[tool.isort]
-line_length = 120
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "N", "PL", "RUF"]
+ignore = [
+    "PLR0913", # too-many-arguments
+    "PLR0917", # too-many-positional-arguments
+    "PLR0912", # too-many-branches
+    "PLR0914", # too-many-locals
+    "PLR0915", # too-many-statements
+    "PLR2004", # magic-value-comparison
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
+]
 
-[tool.pylint."MESSAGES CONTROL"]
-max-line-length = 120
-disable = "fixme"
+[tool.ruff.lint.per-file-ignores]
+"src/ahbicht/content_evaluation/ahb_context.py" = ["PLC0415"]
+# PLC0415: import-outside-toplevel is intentional here (see the file's own comment)
+# E501: a comment inside the raw GRAMMAR string exceeds the line length and can't be noqa'd (interior to a string)
+"src/ahbicht/expressions/condition_expression_parser.py" = ["PLC0415", "E501"]
+# lark Transformer methods must match the grammar's (uppercase) terminal/rule names exactly
+"src/ahbicht/expressions/ahb_expression_evaluation.py" = ["N802"]
+"src/ahbicht/expressions/expression_resolver.py" = ["N802"]
 
 [tool.pytest.ini_options]
 # When the mode is auto, all discovered async tests are considered asyncio-driven

--- a/src/ahbicht/condition_node_builder.py
+++ b/src/ahbicht/condition_node_builder.py
@@ -3,7 +3,7 @@ Module for taking all the condition keys of a condition expression and building 
 If necessary it evaluates the needed attributes.
 """
 
-from typing import Any, Union
+from typing import Any
 
 from ahbicht.content_evaluation.ahb_context import AhbContext
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
@@ -13,7 +13,7 @@ from ahbicht.models.condition_nodes import Hint, RequirementConstraint, Unevalua
 # TRCTransformerArgument is a union of nodes that are already evaluated from a Requirement Constraint (RC) perspective.
 # The Format Constraints (FC) might still be unevaluated. That's why the return type used in the
 # RequirementConstraintTransformer is always an EvaluatedComposition.
-TRCTransformerArgument = Union[RequirementConstraint, UnevaluatedFormatConstraint, Hint]  # pylint:disable=invalid-name
+TRCTransformerArgument = RequirementConstraint | UnevaluatedFormatConstraint | Hint
 
 
 # pylint: disable=no-member, too-few-public-methods

--- a/src/ahbicht/content_evaluation/ahb_context.py
+++ b/src/ahbicht/content_evaluation/ahb_context.py
@@ -9,7 +9,7 @@ and eliminates global mutable state.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
@@ -49,7 +49,7 @@ class AhbContext:
         content_evaluation_result: ContentEvaluationResult,
         edifact_format: EdifactFormat,
         edifact_format_version: EdifactFormatVersion,
-        evaluatable_data: Optional[EvaluatableData[Any]] = None,
+        evaluatable_data: EvaluatableData[Any] | None = None,
     ) -> AhbContext:
         """
         Creates an AhbContext from a ContentEvaluationResult.

--- a/src/ahbicht/content_evaluation/evaluationdatatypes.py
+++ b/src/ahbicht/content_evaluation/evaluationdatatypes.py
@@ -3,7 +3,7 @@ Dataclasses that are relevant in the context of the content_evaluation.
 """
 
 from dataclasses import dataclass, replace
-from typing import Generic, Optional, TypeVar
+from typing import Generic, TypeVar
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
@@ -38,9 +38,8 @@ class EvaluationContext:
     content_evaluation is one zähler entry although there might be multiple zählers present in the message.
     """
 
-    scope: Optional[
-        str
-    ]  # jsonpath that refers to the scope of the content_eval. If None, then "$" = entire message is used as scope.
+    # jsonpath that refers to the scope of the content_eval. If None, then "$" = entire message is used as scope.
+    scope: str | None
 
 
 def copy_evaluation_context(context: EvaluationContext) -> EvaluationContext:

--- a/src/ahbicht/content_evaluation/evaluator_factory.py
+++ b/src/ahbicht/content_evaluation/evaluator_factory.py
@@ -10,7 +10,8 @@ ContentEvaluationResult. Now the methods below are useful. Simply provide a cont
 the evaluators are created based on the already known outcomes. You do not have to actually touch any evaluator code.
 """
 
-from typing import Iterable, Optional, Protocol
+from collections.abc import Iterable
+from typing import Protocol
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
@@ -45,8 +46,8 @@ class _HasEdifactFormatAndFormatVersion(Protocol):
 
 def _set_edifact_format_and_version(
     logic_providers: Iterable[_HasEdifactFormatAndFormatVersion],
-    edifact_format: Optional[EdifactFormat],
-    edifact_format_version: Optional[EdifactFormatVersion],
+    edifact_format: EdifactFormat | None,
+    edifact_format_version: EdifactFormatVersion | None,
 ) -> None:
     for logic_provider in logic_providers:
         if edifact_format is not None:
@@ -57,8 +58,8 @@ def _set_edifact_format_and_version(
 
 def create_hardcoded_evaluators(
     content_evaluation_result: ContentEvaluationResult,
-    edifact_format: Optional[EdifactFormat] = None,
-    edifact_format_version: Optional[EdifactFormatVersion] = None,
+    edifact_format: EdifactFormat | None = None,
+    edifact_format_version: EdifactFormatVersion | None = None,
 ) -> tuple[RcEvaluator, FcEvaluator, HintsProvider, PackageResolver]:
     """
     Creates evaluators based on the given content_evaluation_result
@@ -77,8 +78,8 @@ def create_hardcoded_evaluators(
 
 
 def create_content_evaluation_result_based_evaluators(
-    edifact_format: Optional[EdifactFormat] = None,
-    edifact_format_version: Optional[EdifactFormatVersion] = None,
+    edifact_format: EdifactFormat | None = None,
+    edifact_format_version: EdifactFormatVersion | None = None,
 ) -> tuple[RcEvaluator, FcEvaluator, HintsProvider, PackageResolver]:
     """
     Creates evaluators that expect the content evaluation result to be present in the evaluatble data

--- a/src/ahbicht/content_evaluation/evaluators.py
+++ b/src/ahbicht/content_evaluation/evaluators.py
@@ -8,14 +8,15 @@ import inspect
 import logging
 import re
 from abc import ABC
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
 # pylint: disable=too-few-public-methods
 
 
-class Evaluator(ABC):
+class Evaluator(ABC):  # noqa: B024 -- subclasses are discovered via evaluate_<condition_key> naming, not abstractmethod
     """
     Base of all evaluators.
     To implement a content_evaluation create or update an inheriting class that has edifact_format and
@@ -50,7 +51,7 @@ class Evaluator(ABC):
             "Instantiated %s and found %i evaluation methods", self.__class__.__name__, len(self._evaluation_methods)
         )
 
-    def get_evaluation_method(self, condition_key: str) -> Optional[Callable[..., Any]]:
+    def get_evaluation_method(self, condition_key: str) -> Callable[..., Any] | None:
         """
         Returns the method that evaluates the condition with key condition_key
         :param condition_key: unique key of the condition, e.g. "59"

--- a/src/ahbicht/content_evaluation/expression_check.py
+++ b/src/ahbicht/content_evaluation/expression_check.py
@@ -3,7 +3,8 @@ contains a high-level function that checks if a given expression is valid or not
 """
 
 import asyncio
-from typing import Any, Awaitable, Optional, Union
+from collections.abc import Awaitable
+from typing import Any
 
 from efoli import EdifactFormat, EdifactFormatVersion
 from lark import Token, Tree
@@ -18,11 +19,11 @@ from ahbicht.models.content_evaluation_result import ContentEvaluationResult
 
 
 async def is_valid_expression(  # pylint: disable=too-many-locals
-    expression_or_tree: Union[str, Tree[Token]],
+    expression_or_tree: str | Tree[Token],
     edifact_format: EdifactFormat,
     edifact_format_version: EdifactFormatVersion,
-    ahb_context: Optional[AhbContext] = None,
-) -> tuple[bool, Optional[str]]:
+    ahb_context: AhbContext | None = None,
+) -> tuple[bool, str | None]:
     """
     Returns true iff the given expression is both well-formed and valid.
     An expression is valid if and only if all possible content evaluations lead to a meaningful results.

--- a/src/ahbicht/content_evaluation/fc_evaluators.py
+++ b/src/ahbicht/content_evaluation/fc_evaluators.py
@@ -11,8 +11,9 @@ validate already required data.
 import asyncio
 import inspect
 from abc import ABC
+from collections.abc import Callable, Coroutine
 from contextvars import ContextVar
-from typing import Any, Callable, Coroutine, Optional
+from typing import Any
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData
 from ahbicht.content_evaluation.evaluators import Evaluator
@@ -21,7 +22,7 @@ from ahbicht.models.condition_nodes import EvaluatedFormatConstraint
 from ahbicht.models.content_evaluation_result import ContentEvaluationResult
 from ahbicht.models.evaluation_results import FormatConstraintEvaluationResult
 
-text_to_be_evaluated_by_format_constraint: ContextVar[Optional[str]] = ContextVar(
+text_to_be_evaluated_by_format_constraint: ContextVar[str | None] = ContextVar(
     "text_to_be_evaluated_by_format_constraint", default=None
 )
 """
@@ -144,7 +145,7 @@ class FcEvaluator(Evaluator, ABC):
         ]
         results: list[EvaluatedFormatConstraint] = await asyncio.gather(*tasks)
 
-        result: dict[str, EvaluatedFormatConstraint] = dict(zip(condition_keys, results))
+        result: dict[str, EvaluatedFormatConstraint] = dict(zip(condition_keys, results, strict=False))
         return result
 
 
@@ -169,7 +170,7 @@ class DictBasedFcEvaluator(FcEvaluator):
         except KeyError as key_error:
             raise NotImplementedError(f"No result was provided for {condition_key}.") from key_error
 
-    def get_evaluation_method(self, condition_key: str) -> Optional[Callable[..., Any]]:
+    def get_evaluation_method(self, condition_key: str) -> Callable[..., Any] | None:
         """
         Returns the method that evaluates the condition with key condition_key
         :param condition_key: unique key of the condition, e.g. "59"
@@ -184,7 +185,7 @@ class ContentEvaluationResultBasedFcEvaluator(FcEvaluator):
     Other than the DictBasedFcEvaluator the outcome is not dependent on the initialization but on the evaluatable data.
     """
 
-    def __init__(self, evaluatable_data: Optional[EvaluatableData[Any]] = None) -> None:
+    def __init__(self, evaluatable_data: EvaluatableData[Any] | None = None) -> None:
         super().__init__()
         self._evaluatable_data = evaluatable_data
 
@@ -201,7 +202,7 @@ class ContentEvaluationResultBasedFcEvaluator(FcEvaluator):
         except KeyError as key_error:
             raise NotImplementedError(f"No result was provided for {condition_key}.") from key_error
 
-    def get_evaluation_method(self, condition_key: str) -> Optional[Callable[..., Any]]:
+    def get_evaluation_method(self, condition_key: str) -> Callable[..., Any] | None:
         async def evaluation_method() -> EvaluatedFormatConstraint:
             return await self.evaluate_single_format_constraint(condition_key)
 

--- a/src/ahbicht/content_evaluation/german_strom_and_gas_tag.py
+++ b/src/ahbicht/content_evaluation/german_strom_and_gas_tag.py
@@ -3,9 +3,10 @@ A module to evaluate datetimes and whether they are "on the edge" of a German "S
 """
 
 import re
+from collections.abc import Callable
 from datetime import datetime, time, timedelta
 from datetime import timezone as tz
-from typing import Callable, Literal, Optional, Union
+from typing import Literal
 
 # The problem with the stdlib zoneinfo is, that the availability of timezones via ZoneInfo(zone_key) depends on the OS
 # and system on which you're running it. In some cases "Europe/Berlin" might be available, but generally it's not,
@@ -42,11 +43,11 @@ def _is_edifact_time_str(time_str: str) -> bool:
     return time_str[:-3].isdigit()
 
 
-def _is_edifact_time_str_convertible_to_datetime(time_str: str) -> tuple[bool, Optional[EdifactDateTimeFormat]]:
+def _is_edifact_time_str_convertible_to_datetime(time_str: str) -> tuple[bool, EdifactDateTimeFormat | None]:
     """
     Checks if a EDIFACT time string can be converted to datetime. If not the EdiFactDateTimeFormat is returned.
     """
-    edifact_time_format: Optional[EdifactDateTimeFormat] = None
+    edifact_time_format: EdifactDateTimeFormat | None = None
     if len(time_str) == 2:  # 802 Monat erlaubt: 1, 3, 6, 12
         edifact_time_format = EdifactDateTimeFormat.MM
     elif len(time_str) == 4 and EDIFACT_TIME_QUANTITY_REGEX.match(time_str):  # Z01 ZZRB
@@ -78,7 +79,7 @@ EDIFACT_TIME_QUANTITY_REGEX = re.compile(r"^(?P<quantity>\d{2})(?P<unit>[TWM])(?
 
 
 # the functions below are excessively unit tested; Please add a test case if you suspect their behaviour to be wrong
-def parse_as_datetime(entered_input: str) -> tuple[Optional[datetime], Optional[EvaluatedFormatConstraint]]:
+def parse_as_datetime(entered_input: str) -> tuple[datetime | None, EvaluatedFormatConstraint | None]:
     """
     Try to parse the given entered_input as datetime
     :param entered_input: a string
@@ -167,7 +168,7 @@ def is_gastag_limit(date_time: datetime) -> bool:  # the name is not as speaking
     return german_local_time.hour == 6 and german_local_time.minute == 0 and german_local_time.second == 0
 
 
-def is_xtag_limit(entered_input: str, division: Union[Literal["Strom"], Literal["Gas"]]) -> EvaluatedFormatConstraint:
+def is_xtag_limit(entered_input: str, division: Literal["Strom"] | Literal["Gas"]) -> EvaluatedFormatConstraint:
     """
     Tries to parse the entered_input as datetime and checks if it is the start/end of a Strom- or Gastag
     """
@@ -183,7 +184,5 @@ def is_xtag_limit(entered_input: str, division: Union[Literal["Strom"], Literal[
         raise NotImplementedError(f"The division must either be 'Strom' or 'Gas': '{division}'")
     if xtag_evaluator(date_time):  # type: ignore[arg-type]
         return EvaluatedFormatConstraint(format_constraint_fulfilled=True, error_message=None)
-    error_message = (
-        f"The given datetime '{date_time.isoformat()}' is not the limit of a {division}tag"  # type: ignore[union-attr]
-    )
+    error_message = f"The given datetime '{date_time.isoformat()}' is not the limit of a {division}tag"  # type: ignore[union-attr]
     return EvaluatedFormatConstraint(format_constraint_fulfilled=False, error_message=error_message)

--- a/src/ahbicht/content_evaluation/rc_evaluators.py
+++ b/src/ahbicht/content_evaluation/rc_evaluators.py
@@ -8,7 +8,7 @@ Typical use-cases are for example
 import asyncio
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any
 
 from ahbicht.content_evaluation.evaluationdatatypes import EvaluatableData, EvaluationContext
 from ahbicht.content_evaluation.evaluators import Evaluator
@@ -45,7 +45,7 @@ class RcEvaluator(Evaluator, ABC):
         raise NotImplementedError("Has to be implemented in inheriting class")
 
     async def evaluate_single_condition(
-        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: Optional[EvaluationContext] = None
+        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: EvaluationContext | None = None
     ) -> ConditionFulfilledValue:
         """
         Evaluates the condition with the given key.
@@ -71,7 +71,7 @@ class RcEvaluator(Evaluator, ABC):
         self,
         condition_keys: list[str],
         evaluatable_data: EvaluatableData[Any],
-        condition_keys_with_context: Optional[dict[str, EvaluationContext]] = None,
+        condition_keys_with_context: dict[str, EvaluationContext] | None = None,
     ) -> dict[str, ConditionFulfilledValue]:
         """
         Validate all the conditions provided in condition_keys in their respective context.
@@ -99,7 +99,7 @@ class RcEvaluator(Evaluator, ABC):
 
         results = await asyncio.gather(*tasks)
 
-        result = dict(zip(condition_keys, results))
+        result = dict(zip(condition_keys, results, strict=False))
         return result
 
 
@@ -122,7 +122,7 @@ class DictBasedRcEvaluator(RcEvaluator):
 
     # pylint:disable=unused-argument
     async def evaluate_single_condition(
-        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: Optional[EvaluationContext] = None
+        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: EvaluationContext | None = None
     ) -> ConditionFulfilledValue:
         try:
             return self._results[condition_key]
@@ -141,7 +141,7 @@ class ContentEvaluationResultBasedRcEvaluator(RcEvaluator):
 
     # pylint:disable=unused-argument
     async def evaluate_single_condition(
-        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: Optional[EvaluationContext] = None
+        self, condition_key: str, evaluatable_data: EvaluatableData[Any], context: EvaluationContext | None = None
     ) -> ConditionFulfilledValue:
         content_evaluation_result = ContentEvaluationResult.model_validate(evaluatable_data.body)
         try:

--- a/src/ahbicht/content_evaluation/token_logic_provider.py
+++ b/src/ahbicht/content_evaluation/token_logic_provider.py
@@ -3,7 +3,6 @@ Contains a class that is able to provide any RC/FC Evaluator, HintsProvider or P
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, Union
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
@@ -38,7 +37,7 @@ class TokenLogicProvider(ABC):
 
     @abstractmethod
     def get_hints_provider(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> HintsProvider:
         """
         returns an appropriate HintsProvider for the given edifact_format and edifact_format_version.
@@ -48,7 +47,7 @@ class TokenLogicProvider(ABC):
 
     @abstractmethod
     def get_package_resolver(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> PackageResolver:
         """
         Returns an appropriate PackageResolver for the given edifact_format and edifact_format_version.
@@ -67,7 +66,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
     _unknown_key = "undefined"
 
     @staticmethod
-    def _to_key(edifact_format: Optional[EdifactFormat], format_version: Optional[EdifactFormatVersion]) -> str:
+    def _to_key(edifact_format: EdifactFormat | None, format_version: EdifactFormatVersion | None) -> str:
         """
         because a tuple for format and format version is not hashable / usable as key in a dict this methods
         converts them to a unique and hashable string
@@ -77,7 +76,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
         # we don't care what the key is, it just has to be unique and consistent
         return f"{edifact_format}-{format_version}"
 
-    def __init__(self, inputs: list[Union[Evaluator, PackageResolver, HintsProvider]]) -> None:
+    def __init__(self, inputs: list[Evaluator | PackageResolver | HintsProvider]) -> None:
         self._rc_evaluators: dict[str, RcEvaluator] = {}
         self._fc_evaluators: dict[str, FcEvaluator] = {}
         self._hints_providers: dict[str, HintsProvider] = {}
@@ -112,7 +111,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
             target_dict[key] = instance  # type: ignore[assignment]
 
     def get_fc_evaluator(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> FcEvaluator:
         try:
             return self._fc_evaluators[SingletonTokenLogicProvider._to_key(edifact_format, format_version)]
@@ -122,7 +121,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
             ) from key_error
 
     def get_rc_evaluator(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> RcEvaluator:
         try:
             return self._rc_evaluators[SingletonTokenLogicProvider._to_key(edifact_format, format_version)]
@@ -132,7 +131,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
             ) from key_error
 
     def get_hints_provider(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> HintsProvider:
         try:
             return self._hints_providers[SingletonTokenLogicProvider._to_key(edifact_format, format_version)]
@@ -142,7 +141,7 @@ class SingletonTokenLogicProvider(TokenLogicProvider):
             ) from key_error
 
     def get_package_resolver(
-        self, edifact_format: Optional[EdifactFormat] = None, format_version: Optional[EdifactFormatVersion] = None
+        self, edifact_format: EdifactFormat | None = None, format_version: EdifactFormatVersion | None = None
     ) -> PackageResolver:
         try:
             return self._package_resolvers[SingletonTokenLogicProvider._to_key(edifact_format, format_version)]

--- a/src/ahbicht/expressions/__init__.py
+++ b/src/ahbicht/expressions/__init__.py
@@ -3,7 +3,6 @@ instantiates a "global" logger for all parsing related stuff
 """
 
 import logging
-from typing import Optional
 
 parsing_logger = logging.getLogger("ahbicht.expressions")
 parsing_logger.setLevel(logging.DEBUG)
@@ -20,7 +19,7 @@ class InvalidExpressionError(Exception):
     down an entire ASGI/anyio task group instead of failing the single request. See Hochfrequenz/ahbicht-functions#732.
     """
 
-    def __init__(self, error_message: str, invalid_expression: Optional[str] = None) -> None:
+    def __init__(self, error_message: str, invalid_expression: str | None = None) -> None:
         """
         initialize the exception
         :param invalid_expression: the expression which is invalid (if known)

--- a/src/ahbicht/expressions/ahb_expression_evaluation.py
+++ b/src/ahbicht/expressions/ahb_expression_evaluation.py
@@ -5,7 +5,7 @@ The AhbExpressionTransformer defines the rules how the different parts of the pa
 The used terms are defined in the README.md.
 """
 
-from typing import Awaitable, Union
+from collections.abc import Awaitable
 
 from lark import Token, Transformer, Tree, v_args
 from lark.exceptions import VisitError
@@ -114,7 +114,7 @@ class AhbExpressionTransformer(Transformer):  # type: ignore[type-arg]
     def ahb_expression(
         self,
         list_of_single_requirement_indicator_expressions: list[
-            Union[AhbExpressionEvaluationResult, Awaitable[AhbExpressionEvaluationResult]]
+            AhbExpressionEvaluationResult | Awaitable[AhbExpressionEvaluationResult]
         ],
     ) -> Awaitable[AhbExpressionEvaluationResult]:
         """
@@ -127,7 +127,7 @@ class AhbExpressionTransformer(Transformer):  # type: ignore[type-arg]
     async def _ahb_expression_async(
         self,
         list_of_single_requirement_indicator_expressions: list[
-            Union[AhbExpressionEvaluationResult, Awaitable[AhbExpressionEvaluationResult]]
+            AhbExpressionEvaluationResult | Awaitable[AhbExpressionEvaluationResult]
         ],
     ) -> AhbExpressionEvaluationResult:
         # the thing is that some user funcs (like e.g. 'requirement_indicator') are not async and there's no reason to
@@ -135,15 +135,12 @@ class AhbExpressionTransformer(Transformer):  # type: ignore[type-arg]
         # evaluation results. The utility function 'gather_if_necessary' accounts for that (see its separate tests).
         results = await gather_if_necessary(list_of_single_requirement_indicator_expressions)
         for single_requirement_indicator_expression in results:
-            if (
-                single_requirement_indicator_expression.requirement_constraint_evaluation_result.requirement_constraints_fulfilled
-            ):
+            rc_eval_result = single_requirement_indicator_expression.requirement_constraint_evaluation_result
+            if rc_eval_result.requirement_constraints_fulfilled:
                 # if there are more than one modal mark, the requirement is conditional
                 # even if the one of modal mark itself is not, e.g. `Muss[1] Kann`
                 if len(list_of_single_requirement_indicator_expressions) > 1:
-                    single_requirement_indicator_expression.requirement_constraint_evaluation_result.requirement_is_conditional = (
-                        True
-                    )
+                    rc_eval_result.requirement_is_conditional = True
                 return single_requirement_indicator_expression
         return results[-1]
 
@@ -163,6 +160,6 @@ async def evaluate_ahb_expression_tree(
     try:
         result = AhbExpressionTransformer(ahb_context=ahb_context).transform(parsed_tree)
     except VisitError as visit_err:
-        raise visit_err.orig_exc
+        raise visit_err.orig_exc from None
 
     return await result  # type: ignore[no-any-return]

--- a/src/ahbicht/expressions/base_transformer.py
+++ b/src/ahbicht/expressions/base_transformer.py
@@ -4,7 +4,8 @@ that evaluate trees build from the condition_expression_parser.
 """
 
 from abc import ABC, abstractmethod
-from typing import Generic, Mapping, TypeVar
+from collections.abc import Mapping
+from typing import Generic, TypeVar
 
 from lark import Token, Transformer, v_args
 

--- a/src/ahbicht/expressions/condition_expression_parser.py
+++ b/src/ahbicht/expressions/condition_expression_parser.py
@@ -9,7 +9,7 @@ The used terms are defined in the README_conditions.md.
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from lark import Lark, Token, Tree
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 GRAMMAR = r"""
 ?expression: expression "O"i expression -> or_composition
             | expression "∨" expression -> or_composition // the logical or
-            | expression "V"i expression -> or_composition // a 'v' for those who first chose to introduce logical symbols like ∨ but now can't find them on their keyboard  
+            | expression "V"i expression -> or_composition // a 'v' for those who first chose to introduce logical symbols like ∨ but now can't find them on their keyboard
             | expression "X"i expression -> xor_composition
             | expression "⊻" expression -> xor_composition
             | expression "U"i expression -> and_composition
@@ -86,7 +86,7 @@ def parse_condition_expression_to_tree(condition_expression: str) -> Tree[Token]
 
 
 def extract_categorized_keys_from_tree(
-    tree_or_list: Union[Tree[Token], list[str]], sanitize: bool = False
+    tree_or_list: Tree[Token] | list[str], sanitize: bool = False
 ) -> CategorizedKeyExtract:
     """
     find different types of condition nodes inside the given tree or list of keys.
@@ -146,7 +146,7 @@ async def extract_categorized_keys(
     resolve_packages: bool = False,
     resolve_time_conditions: bool = False,
     replace_time_conditions: bool = False,
-    ahb_context: Optional[AhbContext] = None,
+    ahb_context: AhbContext | None = None,
 ) -> CategorizedKeyExtract:
     """
     Parses the given condition expression and returns CategorizedKeyExtract as a template for content

--- a/src/ahbicht/expressions/expression_builder.py
+++ b/src/ahbicht/expressions/expression_builder.py
@@ -4,7 +4,7 @@ Module to create expressions from scratch.
 
 import re
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, Protocol, Type, TypeVar, Union
+from typing import Generic, Protocol, TypeVar
 
 from ahbicht.models.condition_nodes import (
     ConditionNode,
@@ -27,7 +27,7 @@ class ExpressionBuilder(Generic[SupportedNodes], ABC):
     """
 
     @abstractmethod
-    def get_expression(self) -> Optional[str]:
+    def get_expression(self) -> str | None:
         """
         Returns the expression string or none if there is no expression.
         :return:
@@ -62,20 +62,20 @@ class ExpressionBuilder(Generic[SupportedNodes], ABC):
         raise NotImplementedError("Has to be implemented by inheriting class.")
 
 
-TEffectiveFCExpressionBuilderArguments = Union[  # pylint:disable=invalid-name
-    EvaluatedComposition, UnevaluatedFormatConstraint, Optional[str]
-]  # node types that have an effect on the built format constraint expression
+TEffectiveFCExpressionBuilderArguments = (
+    EvaluatedComposition | UnevaluatedFormatConstraint | str | None
+)  # node types that have an effect on the built format constraint expression
 
-TUneffectiveFCExpressionBuilderArguments = Union[  # pylint:disable=invalid-name
-    RequirementConstraint, EvaluatedComposition, Hint, Type[ConditionNode]
-]  # node types that are formally accepted as argument but don't
+TUneffectiveFCExpressionBuilderArguments = (
+    RequirementConstraint | EvaluatedComposition | Hint | type[ConditionNode]
+)  # node types that are formally accepted as argument but don't
 # have any effect. Instead of checking which nodes contain format constraints all are put into the
 # FormatConstraintExpressionBuilder, but it only has an effect on those with format constraints.
 # Note that EvaluatedComposition is in both classes since they can have format constraints but don't have to.
 
-TSupportedFCExpressionBuilderArguments = Union[  # pylint:disable=invalid-name
-    TEffectiveFCExpressionBuilderArguments, TUneffectiveFCExpressionBuilderArguments
-]
+TSupportedFCExpressionBuilderArguments = (
+    TEffectiveFCExpressionBuilderArguments | TUneffectiveFCExpressionBuilderArguments
+)
 
 
 class FormatConstraintExpressionBuilder(ExpressionBuilder[TSupportedFCExpressionBuilderArguments]):
@@ -93,7 +93,7 @@ class FormatConstraintExpressionBuilder(ExpressionBuilder[TSupportedFCExpression
         Start with a plain expression
         :param init_condition_or_expression: initial format constraint or existing expression
         """
-        self._expression: Optional[str]
+        self._expression: str | None
         if isinstance(init_condition_or_expression, UnevaluatedFormatConstraint):
             # the condition key of the token in expression '[42]' is only '42'
             # so the get a valid expression, we add the square brackets
@@ -113,7 +113,7 @@ class FormatConstraintExpressionBuilder(ExpressionBuilder[TSupportedFCExpression
             # we should never come here
             self._expression = None
 
-    def get_expression(self) -> Optional[str]:
+    def get_expression(self) -> str | None:
         # could add simplifications here
         return self._expression
 
@@ -174,7 +174,7 @@ class HintExpressionBuilder(ExpressionBuilder[ClassesWithHintAttribute]):
     """
 
     @staticmethod
-    def get_hint_text(hinty_object: Optional[_ClassesWithHintAttribute]) -> Optional[str]:
+    def get_hint_text(hinty_object: _ClassesWithHintAttribute | None) -> str | None:
         """
         get the hint from a Hint instance or plain string
         :param hinty_object:
@@ -186,16 +186,16 @@ class HintExpressionBuilder(ExpressionBuilder[ClassesWithHintAttribute]):
             return hinty_object
         return getattr(hinty_object, "hint", None)
 
-    def __init__(self, init_condition: Optional[_ClassesWithHintAttribute]) -> None:
+    def __init__(self, init_condition: _ClassesWithHintAttribute | None) -> None:
         """
         Initialize by providing either a Hint Node or a hint string
         """
         self._expression = HintExpressionBuilder.get_hint_text(init_condition)
 
-    def get_expression(self) -> Optional[str]:
+    def get_expression(self) -> str | None:
         return self._expression
 
-    def land(self, other: Optional[_ClassesWithHintAttribute]) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
+    def land(self, other: _ClassesWithHintAttribute | None) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
         if other is not None:
             if self._expression:
                 self._expression += f" und {HintExpressionBuilder.get_hint_text(other)}"
@@ -203,7 +203,7 @@ class HintExpressionBuilder(ExpressionBuilder[ClassesWithHintAttribute]):
                 self._expression = HintExpressionBuilder.get_hint_text(other)
         return self
 
-    def lor(self, other: Optional[_ClassesWithHintAttribute]) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
+    def lor(self, other: _ClassesWithHintAttribute | None) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
         if other is not None:
             if self._expression:
                 self._expression += f" oder {HintExpressionBuilder.get_hint_text(other)}"
@@ -211,7 +211,7 @@ class HintExpressionBuilder(ExpressionBuilder[ClassesWithHintAttribute]):
                 self._expression = HintExpressionBuilder.get_hint_text(other)
         return self
 
-    def xor(self, other: Optional[_ClassesWithHintAttribute]) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
+    def xor(self, other: _ClassesWithHintAttribute | None) -> "HintExpressionBuilder[ClassesWithHintAttribute]":
         if other is not None:
             if self._expression:
                 self._expression = f"Entweder ({self._expression}) oder ({HintExpressionBuilder.get_hint_text(other)})"
@@ -231,11 +231,11 @@ class FormatErrorMessageExpressionBuilder(ExpressionBuilder[EvaluatedFormatConst
         self._expression = init_condition.error_message
         self.format_constraint_fulfilled = init_condition.format_constraint_fulfilled
 
-    def get_expression(self) -> Optional[str]:
+    def get_expression(self) -> str | None:
         return self._expression
 
     @staticmethod
-    def _wrap_message(msg: Optional[str]) -> str:
+    def _wrap_message(msg: str | None) -> str:
         """
         Wrap a message appropriately for combining with logical operators.
         Use parentheses for compound expressions, single quotes for simple messages.
@@ -252,13 +252,12 @@ class FormatErrorMessageExpressionBuilder(ExpressionBuilder[EvaluatedFormatConst
             # If a format constraint is connected with "logical and" to another format constraint which is fulfilled,
             # then the remaining expression/error message stays the same.
             pass
+        elif self._expression is None:
+            self._expression = other.error_message
         else:
-            if self._expression is None:
-                self._expression = other.error_message
-            else:
-                left_part = self._wrap_message(self._expression)
-                right_part = self._wrap_message(other.error_message)
-                self._expression = f"{left_part} und {right_part}"
+            left_part = self._wrap_message(self._expression)
+            right_part = self._wrap_message(other.error_message)
+            self._expression = f"{left_part} und {right_part}"
         return self
 
     def lor(self, other: EvaluatedFormatConstraint) -> "FormatErrorMessageExpressionBuilder":

--- a/src/ahbicht/expressions/expression_resolver.py
+++ b/src/ahbicht/expressions/expression_resolver.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Awaitable, Optional, Union
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING
 
 from lark import Token, Transformer, Tree
 from lark.exceptions import VisitError
@@ -30,7 +31,7 @@ async def parse_expression_including_unresolved_subexpressions(
     resolve_time_conditions: bool = True,
     replace_time_conditions: bool = True,
     include_package_repeatabilities: bool = False,
-    ahb_context: Optional[AhbContext] = None,
+    ahb_context: AhbContext | None = None,
 ) -> Tree[Token]:
     """
     Parses expressions and resolves its subexpressions,
@@ -50,8 +51,7 @@ async def parse_expression_including_unresolved_subexpressions(
         try:
             expression_tree = parse_condition_expression_to_tree(expression)
         except SyntaxError as condition_syntax_error:
-            # pylint: disable=raise-missing-from
-            raise SyntaxError(f"{ahb_syntax_error.msg} {condition_syntax_error.msg}")
+            raise SyntaxError(f"{ahb_syntax_error.msg} {condition_syntax_error.msg}") from condition_syntax_error
     if resolve_packages:
         # the condition expression inside the ahb expression has to be resolved before trying to resolve packages
         expression_tree = await expand_packages(
@@ -65,7 +65,7 @@ async def parse_expression_including_unresolved_subexpressions(
 async def expand_packages(
     parsed_tree: Tree[Token],
     include_package_repeatabilities: bool = False,
-    ahb_context: Optional[AhbContext] = None,
+    ahb_context: AhbContext | None = None,
 ) -> Tree[Token]:
     """
     Replaces all the "short" packages in parser_tree with the respective "long" condition expressions
@@ -75,7 +75,7 @@ async def expand_packages(
             parsed_tree
         )
     except VisitError as visit_err:
-        raise visit_err.orig_exc
+        raise visit_err.orig_exc from None
     result = await _replace_sub_coroutines_with_awaited_results(result)
     return result
 
@@ -89,7 +89,7 @@ def expand_time_conditions(parsed_tree: Tree[Token], replace_time_conditions: bo
     return result  # type: ignore[no-any-return]
 
 
-async def _replace_sub_coroutines_with_awaited_results(tree: Union[Tree[Token], Awaitable[Tree[Token]]]) -> Tree[Token]:
+async def _replace_sub_coroutines_with_awaited_results(tree: Tree[Token] | Awaitable[Tree[Token]]) -> Tree[Token]:
     """
     awaits all coroutines inside the tree and replaces the coroutines with their respective awaited result.
     returns an updated tree
@@ -102,7 +102,7 @@ async def _replace_sub_coroutines_with_awaited_results(tree: Union[Tree[Token], 
         result = tree
     # todo: check why lark type hints state the return value of scan_values is always Iterator[str]
     sub_results = await asyncio.gather(*result.scan_values(asyncio.iscoroutine))  # type: ignore[call-overload]
-    for coro, sub_result in zip(result.scan_values(asyncio.iscoroutine), sub_results):
+    for coro, sub_result in zip(result.scan_values(asyncio.iscoroutine), sub_results, strict=False):
         for sub_tree in result.iter_subtrees():
             for child_index, child in enumerate(sub_tree.children):
                 if child == coro:
@@ -142,29 +142,28 @@ class PackageExpansionTransformer(Transformer):  # type: ignore[type-arg]
     def __init__(
         self,
         include_package_repeatabilities: bool = False,
-        ahb_context: Optional[AhbContext] = None,
+        ahb_context: AhbContext | None = None,
     ) -> None:
         super().__init__()
         self._ahb_context = ahb_context
         self.include_package_repeatabilities = include_package_repeatabilities
 
-    def package(self, tokens: list[Token]) -> Union[Tree[Token], Awaitable[Tree[Token]]]:
+    def package(self, tokens: list[Token]) -> Tree[Token] | Awaitable[Tree[Token]]:
         """
         try to resolve the package using the PackageResolver from ahb_context
         """
         # The grammar guarantees that there is always exactly 1 package_key token/terminal.
         # But the repeatability token is optional, so the list repeatability_tokens might contain 0 or 1 entries
         # They all come in the same `tokens` list which we split in the following two lines.
-        package_key_token = [t for t in tokens if t.type == "PACKAGE_KEY"][0]
+        package_key_token = next(t for t in tokens if t.type == "PACKAGE_KEY")
         repeatability_tokens = [t for t in tokens if t.type == "REPEATABILITY"]
         single_repeat_token = repeatability_tokens[0] if len(repeatability_tokens) == 1 else None
-        # pylint: disable=unused-variable
         # we parse the repeatability, but we don't to anything with it, yet. Cf. docstring of this class.
-        repeatability: Optional[Repeatability]
+        repeatability: Repeatability | None
         if single_repeat_token:
             repeatability = parse_repeatability(single_repeat_token.value)
         else:
-            repeatability = None
+            repeatability = None  # noqa: F841
 
         # Special case: Package '1P' is always resolved to a hint node.
         # See the docstring of PACKAGE_1P_HINT_KEY for details.
@@ -173,7 +172,7 @@ class PackageExpansionTransformer(Transformer):  # type: ignore[type-arg]
 
         return self._package_async(package_key_token, single_repeat_token)
 
-    async def _package_async(self, package_key_token: Token, repeatability_token: Optional[Token]) -> Tree[Token]:
+    async def _package_async(self, package_key_token: Token, repeatability_token: Token | None) -> Tree[Token]:
         if self._ahb_context is None:
             raise ValueError("ahb_context is required for package resolution")
         resolver = self._ahb_context.package_resolver
@@ -282,9 +281,6 @@ class TimeConditionTransformer(Transformer):  # type: ignore[type-arg]
             # RC 492 = receiver is from division electricity/strom
             # RC 493 = receiver is from division gas
             return parse_condition_expression_to_tree(
-                "([931]∧[932][492]∧[490])⊻"
-                "([931]∧[933][492]∧[491])⊻"
-                "([931]∧[934][493]∧[490])⊻"
-                "([931]∧[935][493]∧[491])"
+                "([931]∧[932][492]∧[490])⊻([931]∧[933][492]∧[491])⊻([931]∧[934][493]∧[490])⊻([931]∧[935][493]∧[491])"
             )
         raise NotImplementedError(f"The time_condition '{time_condition_key}' is not implemented")

--- a/src/ahbicht/expressions/format_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/format_constraint_expression_evaluation.py
@@ -6,7 +6,7 @@ of the format constraint expression tree are handled.
 The used terms are defined in the README_conditions.md.
 """
 
-from typing import Mapping, Optional
+from collections.abc import Mapping
 
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
@@ -81,19 +81,19 @@ def evaluate_format_constraint_tree(
     try:
         result = FormatConstraintTransformer(input_values).transform(parsed_tree)
     except VisitError as visit_err:
-        raise visit_err.orig_exc
+        raise visit_err.orig_exc from None
 
     return result  # type: ignore[no-any-return]
 
 
 async def format_constraint_evaluation(
-    format_constraints_expression: Optional[str],
+    format_constraints_expression: str | None,
     ahb_context: AhbContext,
 ) -> FormatConstraintEvaluationResult:
     """
     Evaluation of the format constraint expression.
     """
-    error_message: Optional[str] = None
+    error_message: str | None = None
     format_constraints_fulfilled: bool
     if not format_constraints_expression:
         format_constraints_fulfilled = True

--- a/src/ahbicht/expressions/hints_provider.py
+++ b/src/ahbicht/expressions/hints_provider.py
@@ -8,8 +8,9 @@ import inspect
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any
 
 from efoli import EdifactFormat, EdifactFormatVersion
 
@@ -57,7 +58,7 @@ class HintsProvider(ABC):
         self.logger.info("Instantiated %s", self.__class__.__name__)
 
     @abstractmethod
-    async def get_hint_text(self, condition_key: str) -> Optional[str]:
+    async def get_hint_text(self, condition_key: str) -> str | None:
         """
         Get the hint text for the given condition key.
         :param condition_key: e.g. "501"
@@ -69,14 +70,14 @@ class HintsProvider(ABC):
         """
         Get Hints for given condition keys by asynchronously awaiting all self.get_hint_text at once
         """
-        results: list[Optional[str]]
+        results: list[str | None]
         if inspect.iscoroutinefunction(self.get_hint_text):
             tasks = [self.get_hint_text(ck) for ck in condition_keys]
             results = await asyncio.gather(*tasks)
         else:
             results = [self.get_hint_text(ck) for ck in condition_keys]  # type: ignore[misc]
         result: dict[str, Hint] = {}
-        for key, value in zip(condition_keys, results):
+        for key, value in zip(condition_keys, results, strict=False):
             if value is None:
                 if raise_key_error:
                     raise KeyError(f"There seems to be no hint implemented with condition key '{key}'.")
@@ -91,15 +92,15 @@ class DictBasedHintsProvider(HintsProvider):
     A Hints Provider that is based on hardcoded values from a dictionary
     """
 
-    def __init__(self, results: Mapping[str, Optional[str]]) -> None:
+    def __init__(self, results: Mapping[str, str | None]) -> None:
         """
         Initialize with a dictionary that contains all the Hinweis texts.
         :param results:
         """
         super().__init__()
-        self._all_hints: Mapping[str, Optional[str]] = results
+        self._all_hints: Mapping[str, str | None] = results
 
-    async def get_hint_text(self, condition_key: str) -> Optional[str]:
+    async def get_hint_text(self, condition_key: str) -> str | None:
         if not condition_key:
             raise ValueError(f"The condition key must not be None/empty but was '{condition_key}'")
         # Special case: Package '1P' hint key is always resolved to the hardcoded hint text.
@@ -139,11 +140,11 @@ class ContentEvaluationResultBasedHintsProvider(HintsProvider):
     data.
     """
 
-    def __init__(self, evaluatable_data: Optional[EvaluatableData[Any]] = None) -> None:
+    def __init__(self, evaluatable_data: EvaluatableData[Any] | None = None) -> None:
         super().__init__()
         self._evaluatable_data = evaluatable_data
 
-    async def get_hint_text(self, condition_key: str) -> Optional[str]:
+    async def get_hint_text(self, condition_key: str) -> str | None:
         # Special case: Package '1P' hint key is always resolved to the hardcoded hint text.
         # See PACKAGE_1P_HINT_KEY docstring for details.
         if condition_key == PACKAGE_1P_HINT_KEY:

--- a/src/ahbicht/expressions/package_expansion.py
+++ b/src/ahbicht/expressions/package_expansion.py
@@ -6,8 +6,9 @@ e.g. if inside a tree "[123P]" is replaced by "[1] U ([2] O [3])".
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any
 
 from efoli import EdifactFormat, EdifactFormatVersion
 from pydantic import RootModel
@@ -52,7 +53,7 @@ class DictBasedPackageResolver(PackageResolver):
     A Package Resolver that is based on hardcoded values from a dictionary
     """
 
-    def __init__(self, results: Mapping[str, Optional[str]]) -> None:
+    def __init__(self, results: Mapping[str, str | None]) -> None:
         """
         Initialize with a dictionary that contains all the condition expressions.
         :param results: maps the package key (e.g. '123') to the package expression (e.g. '[1] U [2]')
@@ -61,7 +62,7 @@ class DictBasedPackageResolver(PackageResolver):
         for key in results.keys():
             if not key.endswith("P"):
                 raise ValueError("The keys should end with 'P' to avoid ambiguities. Use '123P' instead of '123'.")
-        self._all_packages: Mapping[str, Optional[str]] = results
+        self._all_packages: Mapping[str, str | None] = results
 
     async def get_condition_expression(self, package_key: str) -> PackageKeyConditionExpressionMapping:
         if not package_key:
@@ -98,7 +99,7 @@ class JsonFilePackageResolver(DictBasedPackageResolver):
         self.edifact_format_version = edifact_format_version
 
     @staticmethod
-    def _open_and_load_package_mappings(file_path: Path) -> dict[str, Optional[str]]:
+    def _open_and_load_package_mappings(file_path: Path) -> dict[str, str | None]:
         """
         Opens the hint json file and loads it into an attribute of the class.
         The method can read both a dictionary of package key/package expression mappings and a
@@ -121,7 +122,7 @@ class ContentEvaluationResultBasedPackageResolver(PackageResolver):
     evaluatable data.
     """
 
-    def __init__(self, evaluatable_data: Optional[EvaluatableData[Any]] = None) -> None:
+    def __init__(self, evaluatable_data: EvaluatableData[Any] | None = None) -> None:
         super().__init__()
         self._evaluatable_data = evaluatable_data
 

--- a/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
+++ b/src/ahbicht/expressions/requirement_constraint_expression_evaluation.py
@@ -6,7 +6,8 @@ of the condition expression tree are handled.
 The used terms are defined in the README_conditions.md.
 """
 
-from typing import Literal, Mapping, Optional, Type, Union
+from collections.abc import Mapping
+from typing import Literal
 
 from lark import Token, Tree, v_args
 from lark.exceptions import VisitError
@@ -82,10 +83,9 @@ class RequirementConstraintTransformer(BaseTransformer[TRCTransformerArgument, E
         if (
             left.conditions_fulfilled == ConditionFulfilledValue.NEUTRAL
             and right.conditions_fulfilled != ConditionFulfilledValue.NEUTRAL
-            or (
-                right.conditions_fulfilled == ConditionFulfilledValue.NEUTRAL
-                and left.conditions_fulfilled != ConditionFulfilledValue.NEUTRAL
-            )
+        ) or (
+            right.conditions_fulfilled == ConditionFulfilledValue.NEUTRAL
+            and left.conditions_fulfilled != ConditionFulfilledValue.NEUTRAL
         ):
             neutral_element: ConditionNode
             boolean_element: ConditionNode
@@ -163,7 +163,7 @@ class RequirementConstraintTransformer(BaseTransformer[TRCTransformerArgument, E
     def _then_also(
         self,
         format_constraint: UnevaluatedFormatConstraint,
-        other_condition: Type[ConditionNode],
+        other_condition: type[ConditionNode],
     ) -> EvaluatedComposition:
         """
         Evaluates a boolean condition with a format constraint. The functions name indicates its behaviour:
@@ -198,7 +198,7 @@ class RequirementConstraintTransformer(BaseTransformer[TRCTransformerArgument, E
 
         return evaluated_composition
 
-    def then_also_composition(self, left: Type[ConditionNode], right: Type[ConditionNode]) -> EvaluatedComposition:
+    def then_also_composition(self, left: type[ConditionNode], right: type[ConditionNode]) -> EvaluatedComposition:
         """
         A "then also" composition is typically used for format constraints.
         It connects an evaluable expression with a format constraint.
@@ -236,13 +236,13 @@ of the type RequirementConstraint, Hint or FormatConstraint.""")
     try:
         result = RequirementConstraintTransformer(input_values).transform(parsed_tree)
     except VisitError as visit_err:
-        raise visit_err.orig_exc
+        raise visit_err.orig_exc from None
 
     return result  # type: ignore[no-any-return]
 
 
 async def requirement_constraint_evaluation(
-    condition_expression: Union[str, Tree[Token]],
+    condition_expression: str | Tree[Token],
     ahb_context: AhbContext,
 ) -> RequirementConstraintEvaluationResult:
     """
@@ -263,10 +263,10 @@ async def requirement_constraint_evaluation(
 
     resulting_condition_node: EvaluatedComposition = evaluate_requirement_constraint_tree(parsed_tree_rc, input_nodes)
 
-    requirement_constraints_fulfilled: Optional[bool] = (
+    requirement_constraints_fulfilled: bool | None = (
         resulting_condition_node.conditions_fulfilled == ConditionFulfilledValue.FULFILLED
     )
-    requirement_is_conditional: Optional[bool] = True
+    requirement_is_conditional: bool | None = True
     if resulting_condition_node.conditions_fulfilled == ConditionFulfilledValue.NEUTRAL:  # pylint:disable=no-member
         requirement_constraints_fulfilled = True
         requirement_is_conditional = False

--- a/src/ahbicht/expressions/sanitizer.py
+++ b/src/ahbicht/expressions/sanitizer.py
@@ -1,6 +1,6 @@
 """contains a function to sanitize user input/expressions from the AHBs"""
 
-from typing import Literal, Optional, overload
+from typing import Literal, overload
 
 _replacements: dict[str, str] = {
     "\u00a0": " ",  # no-break space,
@@ -15,7 +15,7 @@ def sanitize_expression(expression: Literal[None]) -> Literal[None]: ...
 def sanitize_expression(expression: str) -> str: ...
 
 
-def sanitize_expression(expression: Optional[str]) -> Optional[str]:
+def sanitize_expression(expression: str | None) -> str | None:
     """
     fixes some common issues with expressions from the AHBs
     """

--- a/src/ahbicht/json_serialization/tree_schema.py
+++ b/src/ahbicht/json_serialization/tree_schema.py
@@ -3,7 +3,7 @@ Schemata for the JSON serialization of expressions.
 """
 
 import sys
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeAlias
 
 from lark import Token, Tree
 from pydantic import ConfigDict, PlainSerializer, TypeAdapter
@@ -33,10 +33,10 @@ class _TreeOrTokenDictWithTree(TypedDict):
     tree: _TreeDict
 
 
-_TreeOrTokenDict: TypeAlias = Union[_TreeOrTokenDictWithToken, _TreeOrTokenDictWithTree]
+_TreeOrTokenDict: TypeAlias = _TreeOrTokenDictWithToken | _TreeOrTokenDictWithTree
 
 
-def _serialize_children(t: Union[Tree[Token], Token]) -> Union[_TokenDict, _TreeDict]:
+def _serialize_children(t: Tree[Token] | Token) -> _TokenDict | _TreeDict:
     if isinstance(t, Tree):
         return TREE_ADAPTER.dump_python(t, mode="json")  # type: ignore[no-any-return]
     if isinstance(t, Token):

--- a/src/ahbicht/models/condition_nodes.py
+++ b/src/ahbicht/models/condition_nodes.py
@@ -9,7 +9,7 @@ The used terms are defined in the README_conditions.md.
 """
 
 from enum import Enum
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 # pylint: disable=too-few-public-methods
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -137,7 +137,7 @@ class EvaluatedFormatConstraint(BaseModel):
     """
 
     format_constraint_fulfilled: bool
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
     @model_validator(mode="after")
     def _validate_error_message(self) -> "EvaluatedFormatConstraint":
@@ -175,8 +175,8 @@ class EvaluatedComposition(ConditionNode):
     Node which is returned after a composition of two nodes is evaluated.
     """
 
-    hint: Optional[str] = None  #: text from hints/notes
-    format_constraints_expression: Optional[str] = None
+    hint: str | None = None  #: text from hints/notes
+    format_constraints_expression: str | None = None
     """
     an expression that consists of (initially unevaluated) format constraints that the evaluated field needs to obey
     """

--- a/src/ahbicht/models/content_evaluation_result.py
+++ b/src/ahbicht/models/content_evaluation_result.py
@@ -2,7 +2,6 @@
 This module contains a class to store _all_ kinds of content evaluation results.
 """
 
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field, constr
@@ -17,21 +16,21 @@ class ContentEvaluationResult(BaseModel):
     format constraints have been evaluated)
     """
 
-    hints: dict[str, Optional[str]] = Field(default_factory=dict)  #: maps the key of a hint (e.g. "501" to a hint text)
+    hints: dict[str, str | None] = Field(default_factory=dict)  #: maps the key of a hint (e.g. "501" to a hint text)
 
     #: maps the key of a format constraint to the respective evaluation result
     format_constraints: dict[str, EvaluatedFormatConstraint]
     #: maps the key of a requirement_constraint to the respective evaluation result
     requirement_constraints: dict[str, ConditionFulfilledValue]
 
-    packages: Optional[dict[constr(pattern=r"^\d+P$"), str]] = Field(default=None)  # type: ignore[valid-type]
+    packages: dict[constr(pattern=r"^\d+P$"), str] | None = Field(default=None)  # type: ignore[valid-type]
     """
     maps the key of a package (e.g. '123') to the respective expression (e.g. '[1] U ([2] O [3])'
     """
 
     # pylint:disable=invalid-name
     #: optional guid
-    id: Optional[UUID] = Field(default=None)
+    id: UUID | None = Field(default=None)
 
 
 __all__ = ["ContentEvaluationResult"]

--- a/src/ahbicht/models/enums.py
+++ b/src/ahbicht/models/enums.py
@@ -3,7 +3,6 @@ Enums used in AHB and condition expressions.
 """
 
 from enum import unique
-from typing import Union
 
 from ahbicht import StrEnum
 
@@ -55,7 +54,7 @@ class PrefixOperator(StrEnum):
     The prefix operator works differently from the logical operator in condition expressions!
     The usage of "X" as logical operator is deprecated since 2022-04-01. It will be replaced with the "⊻" symbol.
     """
-    O = "O"
+    O = "O"  # noqa: E741
     """
     The "O" operator means that at least one out of multiple possible qualifiers/codes has to be given.
     This is typically found when describing ways to contact a market partner (CTA): You can use email or phone or fax
@@ -75,7 +74,7 @@ class PrefixOperator(StrEnum):
     """
 
 
-RequirementIndicator = Union[PrefixOperator, ModalMark]
+RequirementIndicator = PrefixOperator | ModalMark
 """
 A Requirement Indicator is either the Merkmal :class:`ModalMark` or the :class:`PrefixOperator` of the
 data element/data element group/segment/segment group at which it is used.

--- a/src/ahbicht/models/evaluation_results.py
+++ b/src/ahbicht/models/evaluation_results.py
@@ -4,7 +4,6 @@ A "result" is the outcome of an evaluation. It requires actual data to be presen
 """
 
 # pylint: disable=too-few-public-methods, no-member,  unused-argument
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -17,13 +16,13 @@ class RequirementConstraintEvaluationResult(BaseModel):
     """
 
     #: true if condition expression in regard to requirement constraints evaluates to true
-    requirement_constraints_fulfilled: Optional[bool]
+    requirement_constraints_fulfilled: bool | None
     #: true if it is dependent on requirement constraints; None if there are unknown condition nodes left
-    requirement_is_conditional: Optional[bool]
+    requirement_is_conditional: bool | None
 
-    format_constraints_expression: Optional[str] = None
+    format_constraints_expression: str | None = None
     #: Hint text that should be displayed in the frontend, e.g. "[501] Hinweis: 'ID der Messlokation'"
-    hints: Optional[str] = None
+    hints: str | None = None
 
 
 class FormatConstraintEvaluationResult(BaseModel):
@@ -35,7 +34,7 @@ class FormatConstraintEvaluationResult(BaseModel):
     format_constraints_fulfilled: bool
 
     #: All error messages that lead to not fulfilling the format constraint expression
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
 
 class AhbExpressionEvaluationResult(BaseModel):

--- a/src/ahbicht/models/mapping_results.py
+++ b/src/ahbicht/models/mapping_results.py
@@ -3,7 +3,7 @@ This module contains classes that are returned by mappers, meaning they contain 
 """
 
 import math
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from efoli import EdifactFormat
 from pydantic import BaseModel, model_validator
@@ -17,7 +17,7 @@ class ConditionKeyConditionTextMapping(BaseModel):
 
     edifact_format: EdifactFormat  #: the format in which the condition is used; e.g. 'UTILMD'
     condition_key: str  #: the key of the condition without square brackets; e.g. '78'
-    condition_text: Optional[str] = None
+    condition_text: str | None = None
     """
     the description of the condition as in the AHB; None if unknown;
     e.g. 'Wenn SG4 STS+7++E02 (Transaktionsgrund: Einzug/Neuanlage)  nicht vorhanden'.
@@ -33,7 +33,7 @@ class PackageKeyConditionExpressionMapping(BaseModel):
 
     edifact_format: EdifactFormat  #: the format in which the package is used; e.g. 'UTILMD'
     package_key: str  #: the key of the package without square brackets but with trailing P; e.g. '10P'
-    package_expression: Optional[str] = None
+    package_expression: str | None = None
     """the expression for which the package is a shortcut; None if unknown e.g. '[20] ∧ [244]'"""
 
     def has_been_resolved_successfully(self) -> bool:
@@ -65,7 +65,7 @@ class Repeatability(BaseModel):
     how often the segment/code has to be repeated (lower, inclusive bound); may be 0 for optional packages
     """
 
-    max_occurrences: Union[int, Literal["n"]]
+    max_occurrences: int | Literal["n"]
     """
     how often the segment/code may be repeated at most (upper, inclusive bound).
     This is inclusive meaning that [123P0..1] leads to max_occurrences==1

--- a/src/ahbicht/utility_functions.py
+++ b/src/ahbicht/utility_functions.py
@@ -5,8 +5,9 @@ Functions that are not clearly related to another module
 import asyncio
 import inspect
 import re
+from collections.abc import Awaitable, Callable
 from re import Match
-from typing import Any, Awaitable, Callable, Literal, Optional, TypeVar, Union
+from typing import Any, Literal, TypeVar
 
 from lark import Token, Tree
 
@@ -21,7 +22,7 @@ _repeatability_pattern = re.compile(
 )  #: a pattern to match "n..m" repeatabilities
 
 
-async def gather_if_necessary(results_and_awaitable_results: list[Union[Result, Awaitable[Result]]]) -> list[Result]:
+async def gather_if_necessary(results_and_awaitable_results: list[Result | Awaitable[Result]]) -> list[Result]:
     """
     Await the awaitables, pass the un-awaitable results
     :param results_and_awaitable_results: heterogeneous list of both Ts and Awaitable[T]s.
@@ -75,11 +76,11 @@ def parse_repeatability(repeatability_string: str) -> Repeatability:
     """
     parses the given string as repeatability; e.g. `17..23` is parsed as min=17, max=23
     """
-    match: Optional[Match[str]] = _repeatability_pattern.match(repeatability_string)
+    match: Match[str] | None = _repeatability_pattern.match(repeatability_string)
     if match is None:
         raise ValueError(f"The given string '{repeatability_string}' could not be parsed as repeatability")
     min_repeatability = int(match["min"])
-    max_repeatability: Union[int, Literal["n"]]
+    max_repeatability: int | Literal["n"]
     try:
         max_repeatability = int(match["max"])
     except TypeError:

--- a/unittests/test_condition_parser.py
+++ b/unittests/test_condition_parser.py
@@ -559,7 +559,7 @@ class TestConditionParser:
 
     async def test_parsing_is_thread_safe(self) -> None:
         async def parse_arbitrary_expression() -> None:
-            random_expr_string = f"[{random.randrange(100,499)}] U [{random.randrange(100,499)}]"
+            random_expr_string = f"[{random.randrange(100, 499)}] U [{random.randrange(100, 499)}]"
             tree = parse_condition_expression_to_tree(random_expr_string)
             await asyncio.sleep(random.randint(500, 1500) / 1000.0)  # wait 0.5-1.5s in each call (avg 1s)
             assert tree is not None

--- a/unittests/test_evaluator_factory.py
+++ b/unittests/test_evaluator_factory.py
@@ -72,8 +72,7 @@ class TestEvaluatorFactory:
         )
         if expected_in_hints is not None:
             assert (
-                expected_in_hints
-                in expression_evaluation_result.requirement_constraint_evaluation_result.hints  # type: ignore[operator]
+                expected_in_hints in expression_evaluation_result.requirement_constraint_evaluation_result.hints  # type: ignore[operator]
             )
         else:
             assert expression_evaluation_result.requirement_constraint_evaluation_result.hints is None

--- a/unittests/test_mixed_sync_async_rc_fc_evaluation.py
+++ b/unittests/test_mixed_sync_async_rc_fc_evaluation.py
@@ -35,7 +35,9 @@ class MixedSyncAsyncRcEvaluator(RcEvaluator):
             assert isinstance(context, EvaluationContext)
         return ConditionFulfilledValue.FULFILLED
 
-    async def evaluate_2(self, evaluatable_data: EvaluatableData, context: EvaluationContext) -> ConditionFulfilledValue:  # type: ignore[type-arg]
+    async def evaluate_2(
+        self, evaluatable_data: EvaluatableData, context: EvaluationContext
+    ) -> ConditionFulfilledValue:  # type: ignore[type-arg]
         assert isinstance(evaluatable_data, EvaluatableData)
         if context is not None:
             assert isinstance(context, EvaluationContext)

--- a/unittests/test_mixed_sync_async_rc_fc_evaluation.py
+++ b/unittests/test_mixed_sync_async_rc_fc_evaluation.py
@@ -36,8 +36,10 @@ class MixedSyncAsyncRcEvaluator(RcEvaluator):
         return ConditionFulfilledValue.FULFILLED
 
     async def evaluate_2(
-        self, evaluatable_data: EvaluatableData, context: EvaluationContext
-    ) -> ConditionFulfilledValue:  # type: ignore[type-arg]
+        self,
+        evaluatable_data: EvaluatableData,  # type: ignore[type-arg]
+        context: EvaluationContext,
+    ) -> ConditionFulfilledValue:
         assert isinstance(evaluatable_data, EvaluatableData)
         if context is not None:
             assert isinstance(context, EvaluationContext)

--- a/unittests/test_requirement_constraint_expression_evaluation.py
+++ b/unittests/test_requirement_constraint_expression_evaluation.py
@@ -207,7 +207,8 @@ class TestRequirementConstraintEvaluation:
         }
         parsed_tree = parse_condition_expression_to_tree(expression)
         result: EvaluatedComposition = evaluate_requirement_constraint_tree(
-            parsed_tree, input_values  # type: ignore[arg-type]
+            parsed_tree,
+            input_values,  # type: ignore[arg-type]
         )
         assert isinstance(result, EvaluatedComposition)
         assert result.conditions_fulfilled == expected_resulting_conditions_fulfilled
@@ -255,7 +256,8 @@ class TestRequirementConstraintEvaluation:
         }
         parsed_tree = parse_condition_expression_to_tree(expression)
         result: EvaluatedComposition = evaluate_requirement_constraint_tree(
-            parsed_tree, input_values  # type: ignore[arg-type]
+            parsed_tree,
+            input_values,  # type: ignore[arg-type]
         )
         assert isinstance(result, ConditionNode)
         assert result.conditions_fulfilled == expected_resulting_conditions_fulfilled
@@ -386,7 +388,8 @@ class TestRequirementConstraintEvaluation:
         input_values["951"] = self._fc_951
         parsed_tree = parse_condition_expression_to_tree("([950] ([2] U [4])) O ([951] ([1] U [3]))")
         actual: EvaluatedComposition = evaluate_requirement_constraint_tree(
-            parsed_tree, input_values  # type: ignore[arg-type]
+            parsed_tree,
+            input_values,  # type: ignore[arg-type]
         )
         assert isinstance(actual, EvaluatedComposition)
         assert actual == expected_evaluated_result

--- a/uv.lock
+++ b/uv.lock
@@ -27,18 +27,16 @@ coverage = [
     { name = "pytest-mock" },
 ]
 dev = [
-    { name = "black", extra = ["jupyter"] },
     { name = "codespell" },
     { name = "coverage" },
-    { name = "isort" },
     { name = "mypy" },
     { name = "nest-asyncio" },
     { name = "pre-commit" },
-    { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-datafiles" },
     { name = "pytest-mock" },
+    { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
     { name = "types-pytz" },
@@ -47,12 +45,8 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
 ]
-formatting = [
-    { name = "black", extra = ["jupyter"] },
-    { name = "isort" },
-]
 linting = [
-    { name = "pylint" },
+    { name = "ruff" },
 ]
 spellcheck = [
     { name = "codespell" },
@@ -89,18 +83,16 @@ coverage = [
     { name = "pytest-mock", specifier = "==3.15.1" },
 ]
 dev = [
-    { name = "black", extras = ["jupyter"], specifier = "==26.5.1" },
     { name = "codespell", specifier = "==2.4.3" },
     { name = "coverage", specifier = "==7.15.2" },
-    { name = "isort", specifier = "==8.0.1" },
     { name = "mypy", extras = ["pydantic"], specifier = "==2.3.0" },
     { name = "nest-asyncio" },
     { name = "pre-commit" },
-    { name = "pylint", specifier = "==4.0.6" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-datafiles", specifier = "==3.0.1" },
     { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-rtd-theme", specifier = "==3.1.0" },
     { name = "types-pytz", specifier = "==2026.3.1.20260727" },
@@ -109,12 +101,8 @@ docs = [
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-rtd-theme", specifier = "==3.1.0" },
 ]
-formatting = [
-    { name = "black", extras = ["jupyter"], specifier = "==26.5.1" },
-    { name = "isort", specifier = "==8.0.1" },
-]
 json-schemas = []
-linting = [{ name = "pylint", specifier = "==4.0.6" }]
+linting = [{ name = "ruff", specifier = "==0.16.0" }]
 spellcheck = [{ name = "codespell", specifier = "==2.4.3" }]
 tests = [
     { name = "pytest", specifier = "==9.1.1" },
@@ -191,27 +179,6 @@ wheels = [
 ]
 
 [[package]]
-name = "astroid"
-version = "4.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
-]
-
-[[package]]
-name = "asttokens"
-version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -227,57 +194,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/84/b3f55026206a9e8820a91503308075ca48eadc515e436731ca01dbe043b3/black-26.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893", size = 1987719, upload-time = "2026-05-18T17:05:02.757Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/34/7db312c5e5783d6e76cffd9d5ac8972a32badae4c6e3288dac0eed8d3bed/black-26.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90", size = 1810083, upload-time = "2026-05-18T17:05:04.302Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e2/e0101e73c2c8727634e2efcb35e2b34bd23ad70dfa673789f5773a591b21/black-26.5.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4", size = 1860633, upload-time = "2026-05-18T17:05:06.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4c/e15c0c5b23cf3651035fe5addcce90e283af3548a3f91bb03d81b83106ab/black-26.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef", size = 1477886, upload-time = "2026-05-18T17:05:07.96Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3f/59d43ade98d2ce5c8dc34a4e46cbecd177e6d55d7d4092969c6003ccc655/black-26.5.1-cp310-cp310-win_arm64.whl", hash = "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22", size = 1277111, upload-time = "2026-05-18T17:05:09.473Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/96/3c3e09f09f44a37aac36b178a279cd19aa7001bd796187a7b162a294c81f/black-26.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c", size = 1970639, upload-time = "2026-05-18T17:05:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ea/5ad117b9ee3ecd933c712bcbae610006e5b7cc9f41c526cd7ed3b6c4124c/black-26.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7", size = 1792130, upload-time = "2026-05-18T17:05:12.983Z" },
-    { url = "https://files.pythonhosted.org/packages/06/3a/7c448bc623fcdfa96672531beb5a616ea5e64f6975955254d7731ffb0ad9/black-26.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59", size = 1846134, upload-time = "2026-05-18T17:05:14.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5b/0b39b3a5917f0657ac014ad2edb58c139553a478adfe7f817abf1622ff6e/black-26.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3", size = 1478883, upload-time = "2026-05-18T17:05:16.542Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/48/dc222692e0f95030db1bbfb6c857e76858bad09058221ea7aae815255327/black-26.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe", size = 1277776, upload-time = "2026-05-18T17:05:18.029Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[package.optional-dependencies]
-jupyter = [
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tokenize-rt" },
 ]
 
 [[package]]
@@ -383,18 +299,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
     { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
     { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -514,24 +418,6 @@ wheels = [
 ]
 
 [[package]]
-name = "decorator"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
-]
-
-[[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -566,20 +452,11 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
-name = "executing"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -625,92 +502,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "ipython"
-version = "8.39.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
-]
-
-[[package]]
-name = "ipython"
-version = "9.15.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
-    "python_full_version == '3.11.*'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/3a/948263ca3b9d65bb2b1b0c521b3a49fad5d59ada58724bd87d2bd5ff3f36/ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e", size = 630895, upload-time = "2026-06-26T11:03:33.809Z" },
-]
-
-[[package]]
-name = "ipython-pygments-lexers"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
-]
-
-[[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
-name = "jedi"
-version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "parso" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -907,27 +698,6 @@ wheels = [
 ]
 
 [[package]]
-name = "matplotlib-inline"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
-]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "mypy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1024,33 +794,12 @@ wheels = [
 ]
 
 [[package]]
-name = "parso"
-version = "0.8.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
-]
-
-[[package]]
-name = "pexpect"
-version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -1085,64 +834,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
-]
-
-[[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
-]
-
-[[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
-    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
-    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "ptyprocess"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
-]
-
-[[package]]
-name = "pure-eval"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -1286,25 +977,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pylint"
-version = "4.0.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astroid" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "dill" },
-    { name = "isort" },
-    { name = "mccabe" },
-    { name = "platformdirs" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomlkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,45 +1043,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/51/276f964496a5714ab9f320896195639086881c2b39c03b5ad13de84acbb8/python_discovery-1.5.0.tar.gz", hash = "sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef", size = 72483, upload-time = "2026-07-21T13:14:14.641Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/7b/14882602ddee241d7984a742fcb423cb4a30fb0d6efc546ac3129fba475a/python_discovery-1.5.0-py3-none-any.whl", hash = "sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98", size = 34205, upload-time = "2026-07-21T13:14:13.398Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
-    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
-    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -1498,6 +1131,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -1618,29 +1276,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stack-data"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
-]
-
-[[package]]
-name = "tokenize-rt"
-version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/ed/8f07e893132d5051d86a553e749d5c89b2a4776eb3a579b72ed61f8559ca/tokenize_rt-6.2.0.tar.gz", hash = "sha256:8439c042b330c553fdbe1758e4a05c0ed460dbbbb24a606f11f0dee75da4cad6", size = 5476, upload-time = "2025-05-23T23:48:00.035Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/f0/3fe8c6e69135a845f4106f2ff8b6805638d4e85c264e70114e8126689587/tokenize_rt-6.2.0-py2.py3-none-any.whl", hash = "sha256:a152bf4f249c847a66497a4a95f63376ed68ac6abf092a2f7cfb29d044ecff44", size = 6004, upload-time = "2025-05-23T23:47:58.812Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1692,24 +1327,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
-]
-
-[[package]]
-name = "traitlets"
-version = "5.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
@@ -1765,13 +1382,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]


### PR DESCRIPTION
## Summary
- Replaces black, isort and pylint with ruff for both linting and formatting; merges the `formatting`/`linting` dependency groups into one `linting` group holding just `ruff==0.16.0`.
- Translates `[tool.black]`/`[tool.isort]`/`[tool.pylint."MESSAGES CONTROL"]` into `[tool.ruff]`/`[tool.ruff.lint]`, keeping a baseline `select` of `E, W, F, I, UP, B, N, PL, RUF` with the usual `PLR0913/PLR0917/PLR0912/PLR0914/PLR0915/PLR2004` and `RUF001/002/003` (non-English text) ignores, plus a handful of narrowly-scoped `per-file-ignores` for genuinely intentional patterns (lark `Transformer` methods that must match uppercase grammar terminal names, deliberate `import-outside-toplevel` to avoid circular imports, and one comment inside a raw grammar string that can't be `noqa`'d).
- Rewrites `.pre-commit-config.yaml` to use `astral-sh/ruff-pre-commit` (`ruff-check --fix` scoped to `src/ahbicht` + `json_schemas/generate_json_schemas.py`, `ruff-format` unscoped).
- Rewrites the CI lint (`pythonlint.yml`) and formatting (`black.yml`) workflows to run `ruff check` / `ruff format --check` over the exact same path scopes the old tools covered, while keeping the matrix values and job names that back required status checks (`Python Code Quality and Lint (linting/type_check)`, `black (3.14, black/isort)`) byte-identical.
- A few real one-line fixes ruff's `B`/`F`/`E741`/`E501` rules surfaced along the way (missing `raise ... from`, an unused import, a too-long attribute chain), plus dead `# pylint: disable=...` comments left in place elsewhere per the migration's own scope (a separate cleanup, not part of this tooling swap).
- Updates the README line that referenced pylint.

## Test plan
- [x] `uv run --group linting ruff check src/ahbicht json_schemas/generate_json_schemas.py` — clean (matches pylint's old scope)
- [x] `uv run --group linting ruff format --check .` — clean, 0 diffs (matches black/isort's old scope), confirmed `*.md` files are excluded
- [ ] CI (mypy --strict, pytest) — not run locally (resource-constrained sandbox); verifying via GitHub Actions on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)